### PR TITLE
[ECO-1197] Extend GitHub actions/pre-commit guidance

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,3 +1,4 @@
+---
 jobs:
   pre-commit:
     runs-on: 'ubuntu-latest'
@@ -9,3 +10,4 @@ jobs:
         extra_args: '--all-files --config cfg/pre-commit-config.yaml --verbose'
 name: 'pre-commit'
 'on': 'pull_request'
+...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,11 @@ From the repository root directory:
 ```sh
 source src/sh/pre-commit.sh
 ```
+
+See the `cfg/` directory for assorted formatter and linter configurations.
+
+### GitHub actions
+
+This repository uses [GitHub actions](https://docs.github.com/en/actions) to perform
+assorted status checks. For example if you submit a pull request but do not run
+[`pre-commit`](#pre-commit) then your pull request might get blocked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,6 @@ See the `cfg/` directory for assorted formatter and linter configurations.
 
 ### GitHub actions
 
-This repository uses [GitHub actions](https://docs.github.com/en/actions) to perform
-assorted status checks. For example if you submit a pull request but do not run
-[`pre-commit`](#pre-commit) then your pull request might get blocked.
+This repository uses [GitHub actions](https://docs.github.com/en/actions) to
+perform assorted status checks. For example if you submit a pull request but do
+not run [`pre-commit`](#pre-commit) then your pull request might get blocked.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Econia v5
 
-<!-- markdownlint-disable-next-line MD013 -->
-
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) <!-- markdownlint-disable-line MD013 -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Econia v5
 
+<!-- markdownlint-disable-next-line MD013 -->
+
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)

--- a/cfg/markdownlint-config.yaml
+++ b/cfg/markdownlint-config.yaml
@@ -1,0 +1,3 @@
+MD013:
+  strict: true
+default: true

--- a/cfg/markdownlint-config.yaml
+++ b/cfg/markdownlint-config.yaml
@@ -1,3 +1,5 @@
+---
 MD013:
   strict: true
 default: true
+...

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -16,7 +16,11 @@ repos:
   rev: '0.7.17'
 -
   hooks:
-  - id: 'markdownlint-fix'
+  -
+    args:
+    - '--config'
+    - 'cfg/markdownlint-config.yaml'
+    id: 'markdownlint-fix'
   repo: 'https://github.com/igorshubovych/markdownlint-cli'
   rev: 'v0.39.0'
 -

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
 -
   hooks:
@@ -46,3 +47,4 @@ repos:
   - id: 'shfmt'
   repo: 'https://github.com/scop/pre-commit-shfmt'
   rev: 'v3.7.0-4'
+...

--- a/cfg/yamllint-config.yaml
+++ b/cfg/yamllint-config.yaml
@@ -1,4 +1,3 @@
-# Used by pre-commit.
 extends: 'default'
 rules:
   braces:

--- a/cfg/yamllint-config.yaml
+++ b/cfg/yamllint-config.yaml
@@ -1,29 +1,39 @@
+---
 extends: 'default'
 rules:
   braces:
     forbid: true
   brackets:
     forbid: true
-  colons: 'enable'
-  commas: 'enable'
-  comments-indentation: 'enable'
+  comments:
+    ignore-shebangs: true
+    level: 'error'
+    min-spaces-from-content: 1
+    require-starting-space: true
+  comments-indentation:
+    level: 'error'
+  document-end: 'enable'
   document-start:
-    present: false
+    level: 'error'
   empty-lines:
     max: 0
     max-end: 1
     max-start: 0
   empty-values: 'enable'
-  hyphens: 'enable'
+  float-values:
+    forbid-inf: false
+    forbid-nan: false
+    forbid-scientific-notation: true
+    require-numeral-before-decimal: true
   indentation:
     check-multi-line-strings: true
     indent-sequences: false
     spaces: 2
-  key-duplicates: false
   key-ordering: 'enable'
-  line-length: 'enable'
-  new-lines: 'enable'
+  octal-values: 'enable'
   quoted-strings:
     quote-type: 'single'
     required: true
-  truthy: 'enable'
+  truthy:
+    level: 'error'
+...


### PR DESCRIPTION
Add GitHub actions guidance to the cotributions guidelines, and more `pre-commit` options/config documentation