### PR TITLE
[ECO-1333] Create rule to mark stale issues and PRs

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -5,11 +5,11 @@ jobs:
     steps:
     - uses: 'actions/stale@v9'
       with:
-        days-before-close: '15'
-        days-before-stale: '45'
+        days-before-close: '1'
+        days-before-stale: '1'
         exempt-issue-labels: 'stale-exempt'
         exempt-pr-labels: 'stale-exempt'
-        operations-per-run: '50' # this is to avoid Github API rate limiting.
+        operations-per-run: '50' # This is to avoid Github API rate limiting.
         stale-issue-message: >
           This issue is stale because it has been open 45 days with no activity.
           Remove the `stale` label or comment -
@@ -21,9 +21,8 @@ jobs:
 name: 'Close stale issues and PRs'
 'on':
   schedule:
-  - cron: '*/5 0 * * *' # cron scheduler syntax
+  - cron: '*/5 0 * * *' # Cron scheduler syntax.
 permissions:
-  # contents: write # this is only necessary if we use the delete-branch option.
   issues: 'write'
   pull-requests: 'write'
 ...

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,0 +1,29 @@
+---
+jobs:
+  stale:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/stale@v9'
+      with:
+        days-before-close: '15'
+        days-before-stale: '45'
+        exempt-issue-labels: 'stale-exempt'
+        exempt-pr-labels: 'stale-exempt'
+        operations-per-run: '50' # this is to avoid Github API rate limiting.
+        stale-issue-message: >
+          This issue is stale because it has been open 45 days with no activity.
+          Remove the `stale` label or comment -
+          otherwise this will be closed in 15 days.
+        stale-pr-message: >
+          This issue is stale because it has been open 45 days with no activity.
+          Remove the `stale` label, comment or push a commit -
+          otherwise this will be closed in 15 days.
+name: 'Close stale issues and PRs'
+'on':
+  schedule:
+  - cron: '*/5 0 * * *' # cron scheduler syntax
+permissions:
+  # contents: write # this is only necessary if we use the delete-branch option.
+  issues: 'write'
+  pull-requests: 'write'
+...


### PR DESCRIPTION
Initial add of the cron job to check for stale issues and PRs every 5 minutes.

The per 5 minutes setting is to test that the workflow works as expected, once merged and tested on test stale issues/PRs, we will set this to once a day.

Right now this will mark issues/PRs as stale after 1 day, and will close them 1 day after that. We can change this back to 45/15 after we've merged and tested this workflow