### PR TITLE
[ECO-1352] Reset cron scheduler and stale/close times back to normal values and delete stale branches

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -7,6 +7,7 @@ jobs:
       with:
         days-before-close: '15'
         days-before-stale: '45'
+        delete-branch: 'true'
         exempt-issue-labels: 'stale-exempt'
         exempt-pr-labels: 'stale-exempt'
         operations-per-run: '50' # This is to avoid Github API rate limiting.
@@ -23,6 +24,7 @@ name: 'Close stale issues and PRs'
   schedule:
   - cron: '0 0 * * *' # Cron scheduler syntax.
 permissions:
+  contents: 'write'
   issues: 'write'
   pull-requests: 'write'
 ...

--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -5,8 +5,8 @@ jobs:
     steps:
     - uses: 'actions/stale@v9'
       with:
-        days-before-close: '1'
-        days-before-stale: '1'
+        days-before-close: '15'
+        days-before-stale: '45'
         exempt-issue-labels: 'stale-exempt'
         exempt-pr-labels: 'stale-exempt'
         operations-per-run: '50' # This is to avoid Github API rate limiting.
@@ -21,7 +21,7 @@ jobs:
 name: 'Close stale issues and PRs'
 'on':
   schedule:
-  - cron: '*/5 0 * * *' # Cron scheduler syntax.
+  - cron: '0 0 * * *' # Cron scheduler syntax.
 permissions:
   issues: 'write'
   pull-requests: 'write'


### PR DESCRIPTION
Reset cron scheduler values back to once per day

Reset stale/close times back to 45/15 (or something else) from 1/1 used for testing

Delete stale branch when PR is stale for X days

---

You can see this action was tested in my forked repo here: https://github.com/xbtmatt/econia-v5/pull/4

and the github action that triggered the branch deletion is here: https://github.com/xbtmatt/econia-v5/actions/runs/8276253969/job/22644504793

Do note that the grace period for deleting a stale PR/issue can sometimes be longer than the period between the last run in CI due to the variance in scheduler times. 

That is, if the branch is deleted after being stale for 1 day and the github action runs again, 23 hours 58 minutes and 39 seconds after marking it as stale, it won't delete it that day, because it technically has been stale for < 1 day. This isn't a big deal but it is something to note.