### PR TITLE
[ECO-1498] Add `CONTRIBUTING` and `README` info for setting up python hooks with pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ results in the comment being marked as resolved.
 [move references]: https://move-language.github.io/move/references.html
 [move signer]: https://move-language.github.io/move/signer.html
 [pre-commit hook]: https://pre-commit.com/hooks.html
-[python hooks readme]: src/python/hooks/README.md
+[python hooks readme]: ./src/python/hooks/README.md
 [reference links]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt
 [run `pre-commit`]: #pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ results in the comment being marked as resolved.
 [move references]: https://move-language.github.io/move/references.html
 [move signer]: https://move-language.github.io/move/signer.html
 [pre-commit hook]: https://pre-commit.com/hooks.html
-[python hooks readme]: https://github.com/econia-labs/econia-v5/src/python/hooks/README.md
+[python hooks readme]: src/python/hooks/README.md
 [reference links]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt
 [run `pre-commit`]: #pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,16 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 ### `pre-commit`
 
 This repository uses [`pre-commit`]. If you add a new filetype, you `SHOULD` add
-a new [hook][pre-commit hook].
+a new [hook][pre-commit hook]. See [adding new hooks] for additional info.
 
-See the `cfg/` directory for assorted formatter and linter configurations.
+In the `cfg/` directory are all of the `pre-commit` configuration files for
+various hooks.
 
-To install our `pre-commit` hooks locally and/or run our python formatter
-scripts, please see the [python hooks readme].
+To set up your local workspace to use `pre-commit` or change any of the hook
+configurations, please see the [pre-commit configuration README].
+
+If you'd like to run our Python formatter locally to pass `pre-commit` checks,
+you can [run our Python format script].
 
 ### GitHub actions
 
@@ -102,6 +106,7 @@ results in the comment being marked as resolved.
    `SomethingEvent`, and `SHALL` be emitted v2-style, consistent with
    the [Aptos Framework v2 event refactors].
 
+[adding new hooks]: ./src/python/hooks/README.md
 [aptos framework v2 event refactors]: https://github.com/aptos-foundation/AIPs/issues/367
 [architecture specification]: doc/architecture-specification.md
 [doc comments]: https://move-language.github.io/move/coding-conventions.html?#comments
@@ -110,10 +115,11 @@ results in the comment being marked as resolved.
 [move format]: https://move-language.github.io/move/coding-conventions.html#formatting
 [move references]: https://move-language.github.io/move/references.html
 [move signer]: https://move-language.github.io/move/signer.html
+[pre-commit configuration readme]: ./cfg/README.md
 [pre-commit hook]: https://pre-commit.com/hooks.html
-[python hooks readme]: ./src/python/hooks/README.md
 [reference links]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt
+[run our python format script]: ./src/python/hooks/README.md#run-our-formatting-script
 [run `pre-commit`]: #pre-commit
 [squash and merge method]: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github
 [vs code markdown+math extension]: https://marketplace.visualstudio.com/items?itemName=goessner.mdmath

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ results in the comment being marked as resolved.
    `SomethingEvent`, and `SHALL` be emitted v2-style, consistent with
    the [Aptos Framework v2 event refactors].
 
-[adding new hooks]: ./src/python/hooks/README.md
+[adding new hooks]: ./cfg/README.md#adding-new-hooks
 [aptos framework v2 event refactors]: https://github.com/aptos-foundation/AIPs/issues/367
 [architecture specification]: doc/architecture-specification.md
 [doc comments]: https://move-language.github.io/move/coding-conventions.html?#comments
@@ -115,7 +115,7 @@ results in the comment being marked as resolved.
 [move format]: https://move-language.github.io/move/coding-conventions.html#formatting
 [move references]: https://move-language.github.io/move/references.html
 [move signer]: https://move-language.github.io/move/signer.html
-[pre-commit configuration readme]: ./cfg/README.md
+[pre-commit configuration readme]: ./cfg/README.md#running-pre-commit-hooks-locally
 [pre-commit hook]: https://pre-commit.com/hooks.html
 [reference links]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,10 @@ These keywords `SHALL` be in `monospace` for ease of identification.
 This repository uses [`pre-commit`]. If you add a new filetype, you `SHOULD` add
 a new [hook][pre-commit hook].
 
-From the repository root directory:
-
-```sh
-source src/sh/pre-commit.sh
-```
-
 See the `cfg/` directory for assorted formatter and linter configurations.
+
+To install our `pre-commit` hooks locally and/or run our python formatter
+scripts, please see the [python hooks readme].
 
 ### GitHub actions
 
@@ -114,6 +111,7 @@ results in the comment being marked as resolved.
 [move references]: https://move-language.github.io/move/references.html
 [move signer]: https://move-language.github.io/move/signer.html
 [pre-commit hook]: https://pre-commit.com/hooks.html
+[python hooks readme]: https://github.com/econia-labs/econia-v5/src/python/hooks/README.md
 [reference links]: https://mdformat.readthedocs.io/en/stable/users/style.html#reference-links
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt
 [run `pre-commit`]: #pre-commit

--- a/cfg/README.md
+++ b/cfg/README.md
@@ -1,0 +1,85 @@
+# Overview
+
+This directory contains all of the configuration files for the various
+`pre-commit` hooks, linters, formatters, and workspace actions that this
+repository uses.
+
+This repository uses [`pre-commit`] hooks to perform various formatter and
+linter verifications upon PR submission. In order to merge a PR, all hooks
+must complete successfully.
+
+## Running `pre-commit` hooks locally
+
+To avoid your PR contributions failing the CI pipeline checks, you can install
+the `pre-commit` hooks locally so that they automatically run right before you
+add a new commit.
+
+### Installing the required tools
+
+To properly install the full `pre-commit` environment for this repository,
+you'll need the following command-line tools:
+
+- `git`, `python`, and `pip` (if you're not using `brew`)
+- `poetry` and `pre-commit`
+
+You can install all of these tools with your preferred package manager.
+If you have `python` and `pip` installed already, you might use:
+
+- `pip install poetry`
+- `pip install pre-commit`
+
+If you use `brew` on MacOS:
+
+- `brew install poetry`
+- `brew install pre-commit`
+
+### Installing the `poetry` and `pre-commit` environments
+
+You'll also need to set up your `poetry` and `pre-commit` environments for this
+repository:
+
+First ensure you're in the `econia-v5` repository at the root directory. If you
+haven't cloned it yet, this might look something like:
+
+```shell
+git clone https://github.com/econia-labs/econia-v5 && cd econia-v5
+```
+
+Then install the Python hooks `poetry` dependencies:
+
+```shell
+poetry install -C src/python/hooks --no-root
+```
+
+To install `pre-commit` to run prior to every time you `git commit ...` when
+relevant files change:
+
+```shell
+pre-commit install --config cfg/pre-commit-config.yaml
+```
+
+Or you can run the hooks manually yourself against all files:
+
+```shell
+pre-commit run --all-files --config cfg/pre-commit-config.yaml
+```
+
+If you'd like to bypass `pre-commit` hooks for any reason once you've installed
+our `pre-commit` hooks with `pre-commit-config.yaml`, you can bypass the checks
+with:
+
+```shell
+git commit -m "Some change pre-commit hooks..." --no-verify
+```
+
+Note that this will allow you to push your commit onto your branch even if it
+fails the `pre-commit` checks, but will likely fail in CI when it runs its
+own `pre-commit` checks.
+
+## Running the Python formatters
+
+If you'd like to automate the Python formatting and linting as much as possible,
+you can [run our Python format script].
+
+[run our python format script]: ../src/python/hooks/README.md#run-our-formatting-script
+[`pre-commit`]: https://pre-commit.com

--- a/cfg/README.md
+++ b/cfg/README.md
@@ -8,6 +8,14 @@ This repository uses [`pre-commit`] hooks to perform various formatter and
 linter verifications upon PR submission. In order to merge a PR, all hooks
 must complete successfully.
 
+## Adding new hooks
+
+If you need to add a new hook to the list of `pre-commit` hooks, you can do so
+by adding it into the `pre-commit-config.yaml` configuration file.
+
+You can add a new hook either by [adding an existing plugin] or [creating a new
+custom hook entirely][creating a new custom hook entirely].
+
 ## Running `pre-commit` hooks locally
 
 To avoid your PR contributions failing the CI pipeline checks, you can install
@@ -81,5 +89,7 @@ own `pre-commit` checks.
 If you'd like to automate the Python formatting and linting as much as possible,
 you can [run our Python format script].
 
+[adding an existing plugin]: https://pre-commit.com/#plugins
+[creating a new custom hook entirely]: https://pre-commit.com/#new-hooks
 [run our python format script]: ../src/python/hooks/README.md#run-our-formatting-script
 [`pre-commit`]: https://pre-commit.com

--- a/src/python/hooks/README.md
+++ b/src/python/hooks/README.md
@@ -1,0 +1,95 @@
+# Overview
+
+The python scripts in this folder are intended to be run in a python-based
+`pre-commit` harness that facilitates running custom python scripts in
+`pre-commit`, both for developers locally and in CI with github actions.
+
+If you are contributing to the python files in this repository for the first
+time, make sure to [install the required tools first].
+
+If you want to quickly format your python files so that they pass the
+`pre-commit` checks, you can [run our formatting script].
+
+## Running `pre-commit` hooks locally
+
+To avoid your PR contributions failing the CI pipeline checks, you can install
+the `pre-commit` hooks locally so that they automatically run right before you
+add a new commit.
+
+### Installing the required tools
+
+To properly install the full `pre-commit` environment for this repository,
+you'll need the following command-line tools:
+
+- `git`, `python`, and `pip` (if you're not using `brew`)
+- `poetry` and `pre-commit`
+
+You can install all of these tools with your preferred package manager.
+If you have `python` and `pip` installed already, you might use:
+
+- `pip install poetry`
+- `pip install pre-commit`
+
+If you use `brew` on MacOS:
+
+- `brew install poetry`
+- `brew install pre-commit`
+
+### Installing the `poetry` and `pre-commit` environments
+
+You'll also need to set up your `poetry` and `pre-commit` environments for this
+repository:
+
+First ensure you're in the `econia-v5` repository at the root directory. If you
+haven't cloned it yet, this might look something like:
+
+```shell
+git clone https://github.com/econia-labs/econia-v5 && cd econia-v5
+```
+
+Then install the python hooks `poetry` dependencies:
+
+```shell
+poetry install -C src/python/hooks --no-root
+```
+
+To install `pre-commit` to run prior to every time you `git commit ...` when
+relevant files change:
+
+```shell
+pre-commit install --config cfg/pre-commit-config.yaml
+```
+
+Or you can run the hooks manually yourself against all files:
+
+```shell
+pre-commit run --all-files --config cfg/pre-commit-config.yaml
+```
+
+If you'd like to bypass `pre-commit` hooks for any reason once you've installed
+our `pre-commit` hooks with `pre-commit-config.yaml`, you can bypass the checks
+with:
+
+```shell
+git commit -m "Some change pre-commit hooks..." --no-verify
+```
+
+Note that this will allow you to push your commit onto your branch even if it
+fails the `pre-commit` checks, but will likely fail in CI when it runs its
+own `pre-commit` checks.
+
+## Running the python formatters
+
+Since our `pre-commit` hooks generally avoid making changes in place during
+the `pre-commit` hook suite, you may need to make manual changes to your files
+to pass the checks.
+
+If your checks fail due to formatting or linting for python files, you can
+easily make necessary changes with our formatting script:
+
+```shell
+./src/sh/python-lint/format.sh
+```
+
+[install the required tools first]: #running-pre-commit-hooks-locally
+[run our formatting script]: #running-the-python-formatters

--- a/src/python/hooks/README.md
+++ b/src/python/hooks/README.md
@@ -81,11 +81,12 @@ own `pre-commit` checks.
 ## Running the python formatters
 
 Since our `pre-commit` hooks generally avoid making changes in place during
-the `pre-commit` hook suite, you may need to make manual changes to your files
+the `pre-commit` hook suite, you may need to make changes to your python files
 to pass the checks.
 
-If your checks fail due to formatting or linting for python files, you can
-easily make necessary changes with our formatting script:
+Some of these changes may require you to make manual changes, but if they
+are issues with formatting and linting, you can easily fix a large portion
+of them by running our formatting script:
 
 ```shell
 ./src/sh/python-lint/format.sh

--- a/src/python/hooks/README.md
+++ b/src/python/hooks/README.md
@@ -1,87 +1,18 @@
 # Overview
 
-The python scripts in this folder are intended to be run in a python-based
-`pre-commit` harness that facilitates running custom python scripts in
+The Python scripts in this folder are intended to be run in a Python-based
+`pre-commit` harness that facilitates running custom Python scripts in
 `pre-commit`, both for developers locally and in CI with github actions.
 
-If you are contributing to the python files in this repository for the first
-time, make sure to [install the required tools first].
+If you haven't yet, make sure to [install the required tools first].
 
-If you want to quickly format your python files so that they pass the
+If you want to quickly format your Python files so that they pass the
 `pre-commit` checks, you can [run our formatting script].
-
-## Running `pre-commit` hooks locally
-
-To avoid your PR contributions failing the CI pipeline checks, you can install
-the `pre-commit` hooks locally so that they automatically run right before you
-add a new commit.
-
-### Installing the required tools
-
-To properly install the full `pre-commit` environment for this repository,
-you'll need the following command-line tools:
-
-- `git`, `python`, and `pip` (if you're not using `brew`)
-- `poetry` and `pre-commit`
-
-You can install all of these tools with your preferred package manager.
-If you have `python` and `pip` installed already, you might use:
-
-- `pip install poetry`
-- `pip install pre-commit`
-
-If you use `brew` on MacOS:
-
-- `brew install poetry`
-- `brew install pre-commit`
-
-### Installing the `poetry` and `pre-commit` environments
-
-You'll also need to set up your `poetry` and `pre-commit` environments for this
-repository:
-
-First ensure you're in the `econia-v5` repository at the root directory. If you
-haven't cloned it yet, this might look something like:
-
-```shell
-git clone https://github.com/econia-labs/econia-v5 && cd econia-v5
-```
-
-Then install the python hooks `poetry` dependencies:
-
-```shell
-poetry install -C src/python/hooks --no-root
-```
-
-To install `pre-commit` to run prior to every time you `git commit ...` when
-relevant files change:
-
-```shell
-pre-commit install --config cfg/pre-commit-config.yaml
-```
-
-Or you can run the hooks manually yourself against all files:
-
-```shell
-pre-commit run --all-files --config cfg/pre-commit-config.yaml
-```
-
-If you'd like to bypass `pre-commit` hooks for any reason once you've installed
-our `pre-commit` hooks with `pre-commit-config.yaml`, you can bypass the checks
-with:
-
-```shell
-git commit -m "Some change pre-commit hooks..." --no-verify
-```
-
-Note that this will allow you to push your commit onto your branch even if it
-fails the `pre-commit` checks, but will likely fail in CI when it runs its
-own `pre-commit` checks.
 
 ## Running the python formatters
 
 Since our `pre-commit` hooks generally avoid making changes in place during
-the `pre-commit` hook suite, you may need to make changes to your python files
+the `pre-commit` hook suite, you may need to make changes to your Python files
 to pass the checks.
 
 Some of these changes may require you to make manual changes, but if they
@@ -92,5 +23,9 @@ of them by running our formatting script:
 ./src/sh/python-lint/format.sh
 ```
 
-[install the required tools first]: #running-pre-commit-hooks-locally
+While you can directly run the Python formatter script, for ease of use, we've
+provided a `.src/sh/python-lint/format.sh` script to verify your Poetry
+dependencies and run anywhere, regardless of your current working directory.
+
+[install the required tools first]: ../../../cfg/README.md
 [run our formatting script]: #running-the-python-formatters


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

The new `pre-commit` hooks and environment requires some set up and clarification, this is intended to provide that.

# Testing

Not relevant since it's basic `*.md` changes for now

# Checklist

- [x] Did you update relevant documentation?
- [x] ~Did you add tests to cover new code or a fixed issue?~
- [x] ~Did you update the changelog?~
