### PR TITLE
[ECO-2220] Format Move files

### DIFF
--- a/src/move/econia/sources/core.move
+++ b/src/move/econia/sources/core.move
@@ -79,21 +79,21 @@ module econia::core {
         market_parameters: MarketParameters,
         extend_ref: ExtendRef,
         base_balances: AssetBalances,
-        quote_balances: AssetBalances,
+        quote_balances: AssetBalances
     }
 
     struct AssetBalances has copy, drop, store {
         book_liquidity: u64,
         pool_liquidity: u64,
         unclaimed_pool_fees: u64,
-        unclaimed_protocol_fees: u64,
+        unclaimed_protocol_fees: u64
     }
 
     struct MarketMetadata has copy, drop, store {
         market_id: u64,
         market_address: address,
         trading_pair: TradingPair,
-        market_parameters: MarketParameters,
+        market_parameters: MarketParameters
     }
 
     struct MarketParameters has copy, drop, store {
@@ -103,12 +103,12 @@ module econia::core {
         eviction_tree_height: u8,
         eviction_price_ratio_ask: Rational,
         eviction_price_ratio_bid: Rational,
-        eviction_liquidity_ratio: Rational,
+        eviction_liquidity_ratio: Rational
     }
 
     struct Rational has copy, drop, store {
         numerator: u64,
-        denominator: u64,
+        denominator: u64
     }
 
     #[resource_group_member(group = ObjectGroup)]
@@ -117,7 +117,7 @@ module econia::core {
         trading_pair: TradingPair,
         market_address: address,
         user: address,
-        open_orders_address: address,
+        open_orders_address: address
     }
 
     struct OpenOrdersMetadata has copy, drop, store {
@@ -125,11 +125,11 @@ module econia::core {
         trading_pair: TradingPair,
         market_address: address,
         user: address,
-        open_orders_address: address,
+        open_orders_address: address
     }
 
     struct OpenOrdersByMarket has key {
-        map: SmartTable<u64, OpenOrdersMetadata>,
+        map: SmartTable<u64, OpenOrdersMetadata>
     }
 
     struct Null has drop, key, store {}
@@ -140,12 +140,12 @@ module econia::core {
         oracle_fee: u64,
         integrator_withdrawal_fee: u64,
         book_map_node_orders: NewMarketNodeOrders,
-        tick_map_node_orders: NewMarketNodeOrders,
+        tick_map_node_orders: NewMarketNodeOrders
     }
 
     struct NewMarketNodeOrders has copy, drop, store {
         inner_node_order: u16,
-        leaf_node_order: u16,
+        leaf_node_order: u16
     }
 
     struct Registry has key {
@@ -153,47 +153,48 @@ module econia::core {
         trading_pair_market_ids: Table<TradingPair, u64>,
         recognized_market_ids: SmartTable<u64, Null>,
         registry_parameters: RegistryParameters,
-        default_market_parameters: MarketParameters,
+        default_market_parameters: MarketParameters
     }
 
     struct Status has key {
-        active: bool,
+        active: bool
     }
 
     struct TradingPair has copy, drop, store {
         base_metadata: Object<Metadata>,
-        quote_metadata: Object<Metadata>,
+        quote_metadata: Object<Metadata>
     }
 
     public entry fun ensure_market_registered(
         registrant: &signer,
         base_metadata: Object<Metadata>,
-        quote_metadata: Object<Metadata>,
-    ) acquires
-        Registry,
-        Status
-    {
+        quote_metadata: Object<Metadata>
+    ) acquires Registry, Status {
         let registry_ref_mut = borrow_registry_mut();
         let trading_pair = TradingPair { base_metadata, quote_metadata };
-        let trading_pair_market_ids_ref_mut = &mut registry_ref_mut.trading_pair_market_ids;
+        let trading_pair_market_ids_ref_mut =
+            &mut registry_ref_mut.trading_pair_market_ids;
         if (table::contains(trading_pair_market_ids_ref_mut, trading_pair)) return;
         assert_active_status();
         assert!(base_metadata != quote_metadata, E_BASE_QUOTE_METADATA_SAME);
-        let utility_asset_metadata = registry_ref_mut.registry_parameters.utility_asset_metadata;
-        let market_registration_fee = registry_ref_mut.registry_parameters.market_registration_fee;
-        let registrant_balance = primary_fungible_store::balance(
-            signer::address_of(registrant),
-            utility_asset_metadata
-        );
+        let utility_asset_metadata =
+            registry_ref_mut.registry_parameters.utility_asset_metadata;
+        let market_registration_fee =
+            registry_ref_mut.registry_parameters.market_registration_fee;
+        let registrant_balance =
+            primary_fungible_store::balance(
+                signer::address_of(registrant),
+                utility_asset_metadata
+            );
         assert!(
             registrant_balance >= market_registration_fee,
-            E_NOT_ENOUGH_UTILITY_ASSET_TO_REGISTER_MARKET,
+            E_NOT_ENOUGH_UTILITY_ASSET_TO_REGISTER_MARKET
         );
         primary_fungible_store::transfer(
             registrant,
             utility_asset_metadata,
             @econia,
-            market_registration_fee,
+            market_registration_fee
         );
         let markets_ref_mut = &mut registry_ref_mut.markets;
         let market_id = table_with_length::length(markets_ref_mut) + 1;
@@ -205,22 +206,25 @@ module econia::core {
             book_liquidity: 0,
             pool_liquidity: 0,
             unclaimed_pool_fees: 0,
-            unclaimed_protocol_fees: 0,
+            unclaimed_protocol_fees: 0
         };
-        move_to(&market_signer, Market {
-            market_id,
-            market_address,
-            trading_pair,
-            market_parameters,
-            extend_ref,
-            base_balances: no_balances,
-            quote_balances: no_balances,
-        });
+        move_to(
+            &market_signer,
+            Market {
+                market_id,
+                market_address,
+                trading_pair,
+                market_parameters,
+                extend_ref,
+                base_balances: no_balances,
+                quote_balances: no_balances
+            }
+        );
         let market_metadata = MarketMetadata {
             market_id,
             market_address,
             trading_pair,
-            market_parameters,
+            market_parameters
         };
         table_with_length::add(markets_ref_mut, market_id, market_metadata);
         table::add(trading_pair_market_ids_ref_mut, trading_pair, market_id);
@@ -229,12 +233,8 @@ module econia::core {
     public entry fun ensure_open_orders_registered(
         user: &signer,
         base_metadata: Object<Metadata>,
-        quote_metadata: Object<Metadata>,
-    ) acquires
-        OpenOrdersByMarket,
-        Registry,
-        Status,
-    {
+        quote_metadata: Object<Metadata>
+    ) acquires OpenOrdersByMarket, Registry, Status, {
         assert_active_status();
         let user_address = signer::address_of(user);
         if (!exists<OpenOrdersByMarket>(user_address)) {
@@ -244,17 +244,21 @@ module econia::core {
         let trading_pair = TradingPair { base_metadata, quote_metadata };
         let (market_id, market_address) =
             get_market_id_and_address_for_registered_pair(trading_pair);
-        let open_orders_map_ref_mut = &mut borrow_global_mut<OpenOrdersByMarket>(user_address).map;
+        let open_orders_map_ref_mut =
+            &mut borrow_global_mut<OpenOrdersByMarket>(user_address).map;
         if (smart_table::contains(open_orders_map_ref_mut, market_id)) return;
         let (constructor_ref, _) = create_nontransferable_sticky_object(user_address);
         let open_orders_address = object::address_from_constructor_ref(&constructor_ref);
-        move_to(&object::generate_signer(&constructor_ref), OpenOrders {
-            market_id,
-            trading_pair,
-            market_address,
-            user: user_address,
-            open_orders_address,
-        });
+        move_to(
+            &object::generate_signer(&constructor_ref),
+            OpenOrders {
+                market_id,
+                trading_pair,
+                market_address,
+                user: user_address,
+                open_orders_address
+            }
+        );
         smart_table::add(
             open_orders_map_ref_mut,
             market_id,
@@ -263,7 +267,7 @@ module econia::core {
                 trading_pair,
                 market_address,
                 user: user_address,
-                open_orders_address,
+                open_orders_address
             }
         );
     }
@@ -280,90 +284,100 @@ module econia::core {
         eviction_price_ratio_bid_numerator_option: Option<u64>,
         eviction_price_ratio_bid_denominator_option: Option<u64>,
         eviction_liquidity_ratio_numerator_option: Option<u64>,
-        eviction_liquidity_ratio_denominator_option: Option<u64>,
+        eviction_liquidity_ratio_denominator_option: Option<u64>
     ) acquires Market, Registry {
         assert_signer_is_econia(econia);
         let updating_default_parameters = option::is_none(&market_id_option);
         let registry_ref_mut = borrow_registry_mut();
-        let (market_parameters_ref_mut, market_address) = if (updating_default_parameters) {
-            (&mut registry_ref_mut.default_market_parameters, @0x0)
-        } else {
-            let market_id = option::destroy_some(market_id_option);
-            let markets_ref_mut = &mut registry_ref_mut.markets;
-            let market_exists = table_with_length::contains(markets_ref_mut, market_id);
-            assert!(market_exists, E_INVALID_MARKET_ID);
-            let market_metadata_ref_mut = table_with_length::borrow_mut(markets_ref_mut, market_id);
-            (
-                &mut market_metadata_ref_mut.market_parameters,
-                market_metadata_ref_mut.market_address,
-            )
-        };
+        let (market_parameters_ref_mut, market_address) =
+            if (updating_default_parameters) {
+                (&mut registry_ref_mut.default_market_parameters, @0x0)
+            } else {
+                let market_id = option::destroy_some(market_id_option);
+                let markets_ref_mut = &mut registry_ref_mut.markets;
+                let market_exists =
+                    table_with_length::contains(markets_ref_mut, market_id);
+                assert!(market_exists, E_INVALID_MARKET_ID);
+                let market_metadata_ref_mut =
+                    table_with_length::borrow_mut(markets_ref_mut, market_id);
+                (
+                    &mut market_metadata_ref_mut.market_parameters,
+                    market_metadata_ref_mut.market_address
+                )
+            };
         set_value_via_option(
             &mut market_parameters_ref_mut.pool_fee_rate,
-            pool_fee_rate_option,
+            pool_fee_rate_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.protocol_fee_rate,
-            protocol_fee_rate_option,
+            protocol_fee_rate_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.max_price_sig_figs,
-            max_price_sig_figs_option,
+            max_price_sig_figs_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_tree_height,
-            eviction_tree_height_option,
+            eviction_tree_height_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_price_ratio_ask.numerator,
-            eviction_price_ratio_ask_numerator_option,
+            eviction_price_ratio_ask_numerator_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_price_ratio_ask.denominator,
-            eviction_price_ratio_ask_denominator_option,
+            eviction_price_ratio_ask_denominator_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_price_ratio_bid.numerator,
-            eviction_price_ratio_bid_numerator_option,
+            eviction_price_ratio_bid_numerator_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_price_ratio_bid.denominator,
-            eviction_price_ratio_bid_denominator_option,
+            eviction_price_ratio_bid_denominator_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_liquidity_ratio.numerator,
-            eviction_liquidity_ratio_numerator_option,
+            eviction_liquidity_ratio_numerator_option
         );
         set_value_via_option(
             &mut market_parameters_ref_mut.eviction_liquidity_ratio.denominator,
-            eviction_liquidity_ratio_denominator_option,
+            eviction_liquidity_ratio_denominator_option
         );
         if (!updating_default_parameters) {
-            borrow_global_mut<Market>(market_address).market_parameters =
-                *market_parameters_ref_mut;
+            borrow_global_mut<Market>(market_address).market_parameters = *market_parameters_ref_mut;
         }
     }
 
     public entry fun update_recognized_markets(
         econia: &signer,
         market_ids_to_recognize: vector<u64>,
-        market_ids_to_unrecognize: vector<u64>,
+        market_ids_to_unrecognize: vector<u64>
     ) acquires Registry {
         assert_signer_is_econia(econia);
         let registry_ref_mut = borrow_registry_mut();
         let recognized_market_ids_ref_mut = &mut registry_ref_mut.recognized_market_ids;
         let n_markets = table_with_length::length(&registry_ref_mut.markets);
-        vector::for_each_ref(&market_ids_to_recognize, |market_id_ref| {
-            if (!smart_table::contains(recognized_market_ids_ref_mut, *market_id_ref)) {
-                assert!(*market_id_ref <= n_markets, E_INVALID_MARKET_ID);
-                smart_table::add(recognized_market_ids_ref_mut, *market_id_ref, Null {});
+        vector::for_each_ref(
+            &market_ids_to_recognize,
+            |market_id_ref| {
+                if (!smart_table::contains(recognized_market_ids_ref_mut, *market_id_ref)) {
+                    assert!(*market_id_ref <= n_markets, E_INVALID_MARKET_ID);
+                    smart_table::add(
+                        recognized_market_ids_ref_mut, *market_id_ref, Null {}
+                    );
+                }
             }
-        });
-        vector::for_each_ref(&market_ids_to_unrecognize, |market_id_ref| {
-            if (smart_table::contains(recognized_market_ids_ref_mut, *market_id_ref)) {
-                smart_table::remove(recognized_market_ids_ref_mut, *market_id_ref);
+        );
+        vector::for_each_ref(
+            &market_ids_to_unrecognize,
+            |market_id_ref| {
+                if (smart_table::contains(recognized_market_ids_ref_mut, *market_id_ref)) {
+                    smart_table::remove(recognized_market_ids_ref_mut, *market_id_ref);
+                }
             }
-        });
+        );
     }
 
     public entry fun update_registry_parameters(
@@ -375,41 +389,41 @@ module econia::core {
         book_map_inner_node_order_option: Option<u16>,
         book_map_leaf_node_order_option: Option<u16>,
         tick_map_inner_node_order_option: Option<u16>,
-        tick_map_leaf_node_order_option: Option<u16>,
+        tick_map_leaf_node_order_option: Option<u16>
     ) acquires Registry {
         assert_signer_is_econia(econia);
         let registry_parameters_ref_mut = &mut borrow_registry_mut().registry_parameters;
         set_object_via_address_option(
             &mut registry_parameters_ref_mut.utility_asset_metadata,
-            utility_asset_metadata_address_option,
+            utility_asset_metadata_address_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.market_registration_fee,
-            market_registration_fee_option,
+            market_registration_fee_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.oracle_fee,
-            oracle_fee_option,
+            oracle_fee_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.integrator_withdrawal_fee,
-            integrator_withdrawal_fee_option,
+            integrator_withdrawal_fee_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.book_map_node_orders.inner_node_order,
-            book_map_inner_node_order_option,
+            book_map_inner_node_order_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.book_map_node_orders.leaf_node_order,
-            book_map_leaf_node_order_option,
+            book_map_leaf_node_order_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.tick_map_node_orders.inner_node_order,
-            tick_map_inner_node_order_option,
+            tick_map_inner_node_order_option
         );
         set_value_via_option(
             &mut registry_parameters_ref_mut.tick_map_node_orders.leaf_node_order,
-            tick_map_leaf_node_order_option,
+            tick_map_leaf_node_order_option
         );
     }
 
@@ -422,13 +436,13 @@ module econia::core {
         assert!(borrow_global<Status>(@econia).active, E_INACTIVE);
     }
 
-    fun assert_open_orders_exists(
-        open_orders_address: address,
-    ) {
+    fun assert_open_orders_exists(open_orders_address: address) {
         assert!(exists<OpenOrders>(open_orders_address), E_NO_OPEN_ORDERS);
     }
 
-    fun assert_open_orders_owner(open_orders_ref: &OpenOrders, user: address) {
+    fun assert_open_orders_owner(
+        open_orders_ref: &OpenOrders, user: address
+    ) {
         assert!(open_orders_ref.user == user, E_DOES_NOT_OWN_OPEN_ORDERS);
     }
 
@@ -437,26 +451,32 @@ module econia::core {
         assert_asset_fully_collateralized(market_ref, false);
     }
 
-    fun assert_asset_fully_collateralized(market_ref: &Market, check_base: bool) {
-        let (asset_metadata, asset_amounts, error_code) = if (check_base) (
-            market_ref.trading_pair.base_metadata,
-            market_ref.base_balances,
-            E_MARKET_NOT_COLLATERALIZED_BASE,
-        ) else (
-            market_ref.trading_pair.quote_metadata,
-            market_ref.quote_balances,
-            E_MARKET_NOT_COLLATERALIZED_QUOTE,
-        );
-        let balance = primary_fungible_store::balance(market_ref.market_address, asset_metadata);
+    fun assert_asset_fully_collateralized(
+        market_ref: &Market, check_base: bool
+    ) {
+        let (asset_metadata, asset_amounts, error_code) =
+            if (check_base)
+                (
+                    market_ref.trading_pair.base_metadata,
+                    market_ref.base_balances,
+                    E_MARKET_NOT_COLLATERALIZED_BASE
+                )
+            else
+                (
+                    market_ref.trading_pair.quote_metadata,
+                    market_ref.quote_balances,
+                    E_MARKET_NOT_COLLATERALIZED_QUOTE
+                );
+        let balance =
+            primary_fungible_store::balance(market_ref.market_address, asset_metadata);
         let minimum_balance = expected_vault_balance(&asset_amounts);
         assert!(balance >= minimum_balance, error_code);
     }
 
     fun expected_vault_balance(asset_amounts_ref: &AssetBalances): u64 {
-        asset_amounts_ref.book_liquidity +
-            asset_amounts_ref.pool_liquidity +
-            asset_amounts_ref.unclaimed_pool_fees +
-            asset_amounts_ref.unclaimed_protocol_fees
+        asset_amounts_ref.book_liquidity + asset_amounts_ref.pool_liquidity
+            + asset_amounts_ref.unclaimed_pool_fees
+            + asset_amounts_ref.unclaimed_protocol_fees
     }
 
     fun create_nontransferable_sticky_object(owner: address): (ConstructorRef, ExtendRef) {
@@ -467,10 +487,9 @@ module econia::core {
         (constructor_ref, extend_ref)
     }
 
-    fun get_market_id_and_address_for_registered_pair(trading_pair: TradingPair): (
-        u64,
-        address,
-    ) acquires Registry {
+    fun get_market_id_and_address_for_registered_pair(
+        trading_pair: TradingPair
+    ): (u64, address) acquires Registry {
         let registry_ref = borrow_registry();
         let trading_pair_market_ids_ref = &registry_ref.trading_pair_market_ids;
         let market_id = *table::borrow(trading_pair_market_ids_ref, trading_pair);
@@ -480,44 +499,48 @@ module econia::core {
     }
 
     fun init_module(econia: &signer) {
-        move_to(econia, Registry {
-            markets: table_with_length::new(),
-            trading_pair_market_ids: table::new(),
-            recognized_market_ids: smart_table::new(),
-            registry_parameters: RegistryParameters {
-                utility_asset_metadata:
-                    object::address_to_object<Metadata>(GENESIS_UTILITY_ASSET_METADATA_ADDRESS),
-                market_registration_fee: GENESIS_MARKET_REGISTRATION_FEE,
-                oracle_fee: GENESIS_ORACLE_FEE,
-                integrator_withdrawal_fee: GENESIS_INTEGRATOR_WITHDRAWAL_FEE,
-                book_map_node_orders: NewMarketNodeOrders {
-                    inner_node_order: GENESIS_BOOK_MAP_INNER_NODE_ORDER,
-                    leaf_node_order: GENESIS_BOOK_MAP_LEAF_NODE_ORDER,
+        move_to(
+            econia,
+            Registry {
+                markets: table_with_length::new(),
+                trading_pair_market_ids: table::new(),
+                recognized_market_ids: smart_table::new(),
+                registry_parameters: RegistryParameters {
+                    utility_asset_metadata: object::address_to_object<Metadata>(
+                        GENESIS_UTILITY_ASSET_METADATA_ADDRESS
+                    ),
+                    market_registration_fee: GENESIS_MARKET_REGISTRATION_FEE,
+                    oracle_fee: GENESIS_ORACLE_FEE,
+                    integrator_withdrawal_fee: GENESIS_INTEGRATOR_WITHDRAWAL_FEE,
+                    book_map_node_orders: NewMarketNodeOrders {
+                        inner_node_order: GENESIS_BOOK_MAP_INNER_NODE_ORDER,
+                        leaf_node_order: GENESIS_BOOK_MAP_LEAF_NODE_ORDER
+                    },
+                    tick_map_node_orders: NewMarketNodeOrders {
+                        inner_node_order: GENESIS_TICK_MAP_INNER_NODE_ORDER,
+                        leaf_node_order: GENESIS_TICK_MAP_LEAF_NODE_ORDER
+                    }
                 },
-                tick_map_node_orders: NewMarketNodeOrders {
-                    inner_node_order: GENESIS_TICK_MAP_INNER_NODE_ORDER,
-                    leaf_node_order: GENESIS_TICK_MAP_LEAF_NODE_ORDER,
-                },
-            },
-            default_market_parameters: MarketParameters {
-                pool_fee_rate: GENESIS_DEFAULT_POOL_FEE_RATE,
-                protocol_fee_rate: GENESIS_DEFAULT_PROTOCOL_FEE_RATE,
-                max_price_sig_figs: GENESIS_DEFAULT_MAX_PRICE_SIG_FIGS,
-                eviction_tree_height: GENESIS_DEFAULT_EVICTION_TREE_HEIGHT,
-                eviction_price_ratio_ask: Rational {
-                    numerator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_ASK_NUMERATOR,
-                    denominator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_ASK_DENOMINATOR,
-                },
-                eviction_price_ratio_bid: Rational {
-                    numerator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_NUMERATOR,
-                    denominator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_DENOMINATOR,
-                },
-                eviction_liquidity_ratio: Rational {
-                    numerator: GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_NUMERATOR,
-                    denominator: GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_DENOMINATOR,
-                },
-            },
-        });
+                default_market_parameters: MarketParameters {
+                    pool_fee_rate: GENESIS_DEFAULT_POOL_FEE_RATE,
+                    protocol_fee_rate: GENESIS_DEFAULT_PROTOCOL_FEE_RATE,
+                    max_price_sig_figs: GENESIS_DEFAULT_MAX_PRICE_SIG_FIGS,
+                    eviction_tree_height: GENESIS_DEFAULT_EVICTION_TREE_HEIGHT,
+                    eviction_price_ratio_ask: Rational {
+                        numerator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_ASK_NUMERATOR,
+                        denominator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_ASK_DENOMINATOR
+                    },
+                    eviction_price_ratio_bid: Rational {
+                        numerator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_NUMERATOR,
+                        denominator: GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_DENOMINATOR
+                    },
+                    eviction_liquidity_ratio: Rational {
+                        numerator: GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_NUMERATOR,
+                        denominator: GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_DENOMINATOR
+                    }
+                }
+            }
+        );
         move_to(econia, Status { active: true });
     }
 
@@ -526,8 +549,7 @@ module econia::core {
     }
 
     fun set_value_via_option<T: copy + drop>(
-        value_ref_mut: &mut T,
-        option: Option<T>
+        value_ref_mut: &mut T, option: Option<T>
     ) {
         if (option::is_some(&option)) {
             *value_ref_mut = option::destroy_some(option);
@@ -535,28 +557,33 @@ module econia::core {
     }
 
     fun set_object_via_address_option<T: key>(
-        object_ref_mut: &mut Object<T>,
-        address_option: Option<address>
+        object_ref_mut: &mut Object<T>, address_option: Option<address>
     ) {
         if (option::is_some(&address_option)) {
-            *object_ref_mut = object::address_to_object<T>(option::destroy_some(address_option));
+            *object_ref_mut = object::address_to_object<T>(
+                option::destroy_some(address_option)
+            );
         }
     }
 
     fun socialize_withdrawal_amount(
         market_ref: &Market,
         amount: u64,
-        withdraw_base: bool,
+        withdraw_base: bool
     ): u64 {
-        let (balances_ref, asset_metadata, error_code) = if (withdraw_base) (
-            &market_ref.base_balances,
-            market_ref.trading_pair.base_metadata,
-            E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_BASE,
-        ) else (
-            &market_ref.quote_balances,
-            market_ref.trading_pair.quote_metadata,
-            E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_QUOTE,
-        );
+        let (balances_ref, asset_metadata, error_code) =
+            if (withdraw_base)
+                (
+                    &market_ref.base_balances,
+                    market_ref.trading_pair.base_metadata,
+                    E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_BASE
+                )
+            else
+                (
+                    &market_ref.quote_balances,
+                    market_ref.trading_pair.quote_metadata,
+                    E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_QUOTE
+                );
         let expected_vault_balance = expected_vault_balance(balances_ref);
         let actual_vault_balance =
             primary_fungible_store::balance(market_ref.market_address, asset_metadata);
@@ -567,9 +594,13 @@ module econia::core {
         (numerator / denominator as u64)
     }
 
-    inline fun borrow_registry(): &Registry { borrow_global<Registry>(@econia) }
+    inline fun borrow_registry(): &Registry {
+        borrow_global<Registry>(@econia)
+    }
 
-    inline fun borrow_registry_mut(): &mut Registry { borrow_global_mut<Registry>(@econia) }
+    inline fun borrow_registry_mut(): &mut Registry {
+        borrow_global_mut<Registry>(@econia)
+    }
 
     #[test_only]
     const MARKET_REGISTRANT_FOR_TEST: address = @0xace;
@@ -592,7 +623,7 @@ module econia::core {
         eviction_price_ratio_bid_numerator: u64,
         eviction_price_ratio_bid_denominator: u64,
         eviction_liquidity_ratio_numerator: u64,
-        eviction_liquidity_ratio_denominator: u64,
+        eviction_liquidity_ratio_denominator: u64
     ) {
         assert!(market_parameters.pool_fee_rate == pool_fee_rate, 0);
         assert!(market_parameters.protocol_fee_rate == protocol_fee_rate, 0);
@@ -619,7 +650,7 @@ module econia::core {
         quote_book_liquidity: u64,
         quote_pool_liquidity: u64,
         quote_unclaimed_pool_fees: u64,
-        quote_unclaimed_protocol_fees: u64,
+        quote_unclaimed_protocol_fees: u64
     ) acquires Market {
         let market_ref = borrow_global<Market>(market_address);
         let base_balances = market_ref.base_balances;
@@ -631,20 +662,26 @@ module econia::core {
         assert!(quote_balances.book_liquidity == quote_book_liquidity, 0);
         assert!(quote_balances.pool_liquidity == quote_pool_liquidity, 0);
         assert!(quote_balances.unclaimed_pool_fees == quote_unclaimed_pool_fees, 0);
-        assert!(quote_balances.unclaimed_protocol_fees == quote_unclaimed_protocol_fees, 0);
+        assert!(
+            quote_balances.unclaimed_protocol_fees == quote_unclaimed_protocol_fees, 0
+        );
     }
 
     #[test_only]
     public fun assert_vault_values(
         market_address: address,
         base_expected: u64,
-        quote_expected: u64,
+        quote_expected: u64
     ) acquires Market {
         let market_ref = borrow_global<Market>(market_address);
         let metadata = market_ref.trading_pair.base_metadata;
-        assert!(primary_fungible_store::balance(market_address, metadata) == base_expected, 0);
+        assert!(
+            primary_fungible_store::balance(market_address, metadata) == base_expected, 0
+        );
         metadata = market_ref.trading_pair.quote_metadata;
-        assert!(primary_fungible_store::balance(market_address, metadata) == quote_expected, 0);
+        assert!(
+            primary_fungible_store::balance(market_address, metadata) == quote_expected, 0
+        );
     }
 
     #[test_only]
@@ -657,14 +694,18 @@ module econia::core {
         book_map_inner_node_order: u16,
         book_map_leaf_node_order: u16,
         tick_map_inner_node_order: u16,
-        tick_map_leaf_node_order: u16,
+        tick_map_leaf_node_order: u16
     ) {
         let utility_asset_metadata_address_to_check =
             object::object_address(&registry_parameters.utility_asset_metadata);
-        assert!(utility_asset_metadata_address_to_check == utility_asset_metadata_address, 0);
+        assert!(
+            utility_asset_metadata_address_to_check == utility_asset_metadata_address, 0
+        );
         assert!(registry_parameters.market_registration_fee == market_registration_fee, 0);
         assert!(registry_parameters.oracle_fee == oracle_fee, 0);
-        assert!(registry_parameters.integrator_withdrawal_fee == integrator_withdrawal_fee, 0);
+        assert!(
+            registry_parameters.integrator_withdrawal_fee == integrator_withdrawal_fee, 0
+        );
         let node_orders = registry_parameters.book_map_node_orders;
         assert!(node_orders.inner_node_order == book_map_inner_node_order, 0);
         assert!(node_orders.leaf_node_order == book_map_leaf_node_order, 0);
@@ -679,7 +720,7 @@ module econia::core {
         market_id: u64,
         trading_pair: TradingPair,
         market_address: address,
-        user: address,
+        user: address
     ) acquires OpenOrders {
         let open_orders_ref = borrow_global<OpenOrders>(open_orders_address);
         assert!(open_orders_ref.market_id == market_id, 0);
@@ -738,11 +779,12 @@ module econia::core {
     }
 
     #[test_only]
-    public fun ensure_markets_registered_for_test() acquires Registry, Status  {
+    public fun ensure_markets_registered_for_test() acquires Registry, Status {
         ensure_market_registered_for_test();
         let trading_pair_flipped = get_test_trading_pair_flipped();
         let registry_ref = borrow_global<Registry>(@econia);
-        if (table::contains(&registry_ref.trading_pair_market_ids, trading_pair_flipped)) return;
+        if (table::contains(&registry_ref.trading_pair_market_ids, trading_pair_flipped))
+            return;
         mint_fa_apt_to_market_registrant();
         ensure_market_registered(
             &get_signer(MARKET_REGISTRANT_FOR_TEST),
@@ -752,18 +794,14 @@ module econia::core {
     }
 
     #[test_only]
-    public fun ensure_open_orders_registered_for_test(): (
-        address,
-        address
-    ) acquires
-        OpenOrdersByMarket,
-        Registry,
-        Status
-    {
+    public fun ensure_open_orders_registered_for_test(): (address, address) acquires OpenOrdersByMarket, Registry, Status {
         let market_address = ensure_market_registered_for_test();
         let (base_metadata, quote_metadata) = test_assets::get_metadata();
-        ensure_open_orders_registered(&get_signer(USER_FOR_TEST), base_metadata, quote_metadata);
-        let open_orders_by_market_map_ref = &borrow_global<OpenOrdersByMarket>(USER_FOR_TEST).map;
+        ensure_open_orders_registered(
+            &get_signer(USER_FOR_TEST), base_metadata, quote_metadata
+        );
+        let open_orders_by_market_map_ref =
+            &borrow_global<OpenOrdersByMarket>(USER_FOR_TEST).map;
         let open_orders_metadata_ref =
             smart_table::borrow(open_orders_by_market_map_ref, MARKET_ID_FOR_TEST);
         let open_orders_address = open_orders_metadata_ref.open_orders_address;
@@ -771,7 +809,9 @@ module econia::core {
     }
 
     #[test_only]
-    public fun get_signer(addr: address): signer { account::create_signer_for_test(addr) }
+    public fun get_signer(addr: address): signer {
+        account::create_signer_for_test(addr)
+    }
 
     #[test, expected_failure(abort_code = E_INACTIVE)]
     fun test_assert_active_status_inactive() acquires Status {
@@ -781,7 +821,9 @@ module econia::core {
     }
 
     #[test, expected_failure(abort_code = E_NOT_ECONIA)]
-    fun test_set_status_not_econia() acquires Status { set_status(&get_signer(@0x0), false); }
+    fun test_set_status_not_econia() acquires Status {
+        set_status(&get_signer(@0x0), false);
+    }
 
     #[test, expected_failure(abort_code = E_NOT_ECONIA)]
     fun test_assert_signer_is_econia_not_econia() {
@@ -794,13 +836,7 @@ module econia::core {
     }
 
     #[test, expected_failure(abort_code = E_DOES_NOT_OWN_OPEN_ORDERS)]
-    fun test_assert_open_orders_owner_does_not_own_open_orders()
-    acquires
-        OpenOrders,
-        OpenOrdersByMarket,
-        Registry,
-        Status,
-    {
+    fun test_assert_open_orders_owner_does_not_own_open_orders() acquires OpenOrders, OpenOrdersByMarket, Registry, Status, {
         let (_, open_orders_address) = ensure_open_orders_registered_for_test();
         assert_open_orders_owner(borrow_global<OpenOrders>(open_orders_address), @0x0);
     }
@@ -813,21 +849,16 @@ module econia::core {
     }
 
     #[test]
-    fun test_open_orders_exists_and_correct_owner()
-    acquires
-        OpenOrders,
-        OpenOrdersByMarket,
-        Registry,
-        Status,
-    {
+    fun test_open_orders_exists_and_correct_owner() acquires OpenOrders, OpenOrdersByMarket, Registry, Status, {
         let (_, open_orders_address) = ensure_open_orders_registered_for_test();
         assert_open_orders_exists(open_orders_address);
-        assert_open_orders_owner(borrow_global<OpenOrders>(open_orders_address), USER_FOR_TEST);
+        assert_open_orders_owner(
+            borrow_global<OpenOrders>(open_orders_address), USER_FOR_TEST
+        );
     }
 
     #[test, expected_failure(abort_code = E_MARKET_NOT_COLLATERALIZED_BASE)]
-    fun test_assert_market_fully_collateralized_market_not_collateralized_base()
-    acquires Market, Registry, Status {
+    fun test_assert_market_fully_collateralized_market_not_collateralized_base() acquires Market, Registry, Status {
         let market_address = ensure_market_registered_for_test();
         let market_ref_mut = borrow_global_mut<Market>(market_address);
         market_ref_mut.base_balances.pool_liquidity = 1;
@@ -835,8 +866,7 @@ module econia::core {
     }
 
     #[test, expected_failure(abort_code = E_MARKET_NOT_COLLATERALIZED_QUOTE)]
-    fun test_assert_market_fully_collateralized_market_not_collateralized_quote()
-    acquires Market, Registry, Status {
+    fun test_assert_market_fully_collateralized_market_not_collateralized_quote() acquires Market, Registry, Status {
         let market_address = ensure_market_registered_for_test();
         let market_ref_mut = borrow_global_mut<Market>(market_address);
         market_ref_mut.quote_balances.pool_liquidity = 1;
@@ -844,7 +874,7 @@ module econia::core {
     }
 
     #[test]
-    fun test_socialize_withdrawal_amount() acquires Market, Registry, Status{
+    fun test_socialize_withdrawal_amount() acquires Market, Registry, Status {
         let market_address = ensure_market_registered_for_test();
         let market_ref_mut = borrow_global_mut<Market>(market_address);
         assert!(socialize_withdrawal_amount(market_ref_mut, 0, true) == 0, 0);
@@ -866,16 +896,16 @@ module econia::core {
     }
 
     #[test, expected_failure(abort_code = E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_BASE)]
-    fun test_socialize_withdrawal_amount_withdrawal_exceeds_expected_vault_balance_base()
-    acquires Market, Registry, Status {
+    fun test_socialize_withdrawal_amount_withdrawal_exceeds_expected_vault_balance_base() acquires Market, Registry, Status {
         let market_address = ensure_market_registered_for_test();
         let market_ref = borrow_global<Market>(market_address);
         socialize_withdrawal_amount(market_ref, 10, true);
     }
 
-    #[test, expected_failure(abort_code = E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_QUOTE)]
-    fun test_socialize_withdrawal_amount_withdrawal_exceeds_expected_vault_balance_quote()
-    acquires Market, Registry, Status {
+    #[test, expected_failure(
+        abort_code = E_WITHDRAWAL_EXCEEDS_EXPECTED_VAULT_BALANCE_QUOTE
+    )]
+    fun test_socialize_withdrawal_amount_withdrawal_exceeds_expected_vault_balance_quote() acquires Market, Registry, Status {
         let market_address = ensure_market_registered_for_test();
         let market_ref = borrow_global<Market>(market_address);
         socialize_withdrawal_amount(market_ref, 10, false);
@@ -903,7 +933,7 @@ module econia::core {
             GENESIS_BOOK_MAP_INNER_NODE_ORDER,
             GENESIS_BOOK_MAP_LEAF_NODE_ORDER,
             GENESIS_TICK_MAP_INNER_NODE_ORDER,
-            GENESIS_TICK_MAP_LEAF_NODE_ORDER,
+            GENESIS_TICK_MAP_LEAF_NODE_ORDER
         );
         assert_market_parameters(
             registry_ref.default_market_parameters,
@@ -916,7 +946,7 @@ module econia::core {
             GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_NUMERATOR,
             GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_DENOMINATOR,
             GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_NUMERATOR,
-            GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_DENOMINATOR,
+            GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_DENOMINATOR
         );
     }
 
@@ -927,7 +957,11 @@ module econia::core {
         let trading_pair_market_ids_ref = &registry_ref.trading_pair_market_ids;
         let trading_pair = get_test_trading_pair();
         let trading_pair_flipped = get_test_trading_pair_flipped();
-        assert!(*table::borrow(trading_pair_market_ids_ref, trading_pair) == MARKET_ID_FOR_TEST, 0);
+        assert!(
+            *table::borrow(trading_pair_market_ids_ref, trading_pair)
+                == MARKET_ID_FOR_TEST,
+            0
+        );
         assert!(*table::borrow(trading_pair_market_ids_ref, trading_pair_flipped) == 2, 0);
         let default_market_parameters = registry_ref.default_market_parameters;
         let market_metadata = *table_with_length::borrow(&registry_ref.markets, 1);
@@ -959,7 +993,7 @@ module econia::core {
         ensure_market_registered(
             &get_signer(MARKET_REGISTRANT_FOR_TEST),
             quote_metadata,
-            base_metadata,
+            base_metadata
         );
     }
 
@@ -967,16 +1001,13 @@ module econia::core {
     fun test_ensure_market_registered_base_quote_metadata_same() acquires Registry, Status {
         ensure_module_initialized_for_test();
         let (metadata, _) = test_assets::get_metadata();
-        ensure_market_registered(&get_signer(MARKET_REGISTRANT_FOR_TEST), metadata, metadata);
+        ensure_market_registered(
+            &get_signer(MARKET_REGISTRANT_FOR_TEST), metadata, metadata
+        );
     }
 
     #[test]
-    fun test_ensure_open_orders_registered() acquires
-        OpenOrders,
-        OpenOrdersByMarket,
-        Registry,
-        Status
-    {
+    fun test_ensure_open_orders_registered() acquires OpenOrders, OpenOrdersByMarket, Registry, Status {
         ensure_market_registered_for_test();
         let (base_metadata, quote_metadata) = test_assets::get_metadata();
         ensure_open_orders_registered(
@@ -985,10 +1016,12 @@ module econia::core {
             quote_metadata
         );
         let registry = borrow_registry();
-        let market_metadata = *table_with_length::borrow(&registry.markets, MARKET_ID_FOR_TEST);
+        let market_metadata =
+            *table_with_length::borrow(&registry.markets, MARKET_ID_FOR_TEST);
         let trading_pair = market_metadata.trading_pair;
         let market_address = market_metadata.market_address;
-        let open_orders_by_market_map_ref = &borrow_global<OpenOrdersByMarket>(USER_FOR_TEST).map;
+        let open_orders_by_market_map_ref =
+            &borrow_global<OpenOrdersByMarket>(USER_FOR_TEST).map;
         let open_orders_metadata =
             *smart_table::borrow(open_orders_by_market_map_ref, MARKET_ID_FOR_TEST);
         assert!(open_orders_metadata.market_id == MARKET_ID_FOR_TEST, 0);
@@ -1000,7 +1033,7 @@ module econia::core {
             MARKET_ID_FOR_TEST,
             trading_pair,
             market_address,
-            USER_FOR_TEST,
+            USER_FOR_TEST
         );
         ensure_open_orders_registered(
             &get_signer(USER_FOR_TEST),
@@ -1046,7 +1079,7 @@ module econia::core {
             option::none(),
             option::none(),
             option::none(),
-            option::none(),
+            option::none()
         );
         assert_registry_parameters(
             borrow_registry().registry_parameters,
@@ -1057,7 +1090,7 @@ module econia::core {
             GENESIS_BOOK_MAP_INNER_NODE_ORDER,
             GENESIS_BOOK_MAP_LEAF_NODE_ORDER,
             GENESIS_TICK_MAP_INNER_NODE_ORDER,
-            GENESIS_TICK_MAP_LEAF_NODE_ORDER,
+            GENESIS_TICK_MAP_LEAF_NODE_ORDER
         );
         test_assets::ensure_assets_initialized();
         let (new_metadata, _) = test_assets::get_metadata();
@@ -1071,7 +1104,7 @@ module econia::core {
             option::some(4),
             option::some(5),
             option::some(6),
-            option::some(7),
+            option::some(7)
         );
         assert_registry_parameters(
             borrow_registry().registry_parameters,
@@ -1102,7 +1135,7 @@ module econia::core {
             option::none(),
             option::none(),
             option::none(),
-            option::none(),
+            option::none()
         );
         let registry = borrow_registry();
         let markets_ref = &registry.markets;
@@ -1121,7 +1154,7 @@ module econia::core {
             GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_NUMERATOR,
             GENESIS_DEFAULT_EVICTION_PRICE_RATIO_BID_DENOMINATOR,
             GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_NUMERATOR,
-            GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_DENOMINATOR,
+            GENESIS_DEFAULT_EVICTION_LIQUIDITY_RATIO_DENOMINATOR
         );
         update_market_parameters(
             &econia,
@@ -1135,7 +1168,7 @@ module econia::core {
             option::some(8),
             option::some(9),
             option::some(10),
-            option::some(11),
+            option::some(11)
         );
         assert_market_parameters(
             borrow_registry().default_market_parameters,
@@ -1148,7 +1181,7 @@ module econia::core {
             8,
             9,
             10,
-            11,
+            11
         )
     }
 
@@ -1167,8 +1200,7 @@ module econia::core {
             option::none(),
             option::none(),
             option::none(),
-            option::none(),
+            option::none()
         );
     }
-
 }

--- a/src/move/econia/sources/rational.move
+++ b/src/move/econia/sources/rational.move
@@ -23,21 +23,28 @@ module econia::rational {
         right_numerator: u64,
         right_denominator: u64
     ): u8 {
-        let (a, b) = (
-            (left_numerator as u128) * (right_denominator as u128),
-            (right_numerator as u128) * (left_denominator as u128),
-        );
-        if (a > b) COMPARE_LEFT_GREATER else if (a < b) COMPARE_RIGHT_GREATER else COMPARE_EQUAL
+        let (a, b) =
+            ((left_numerator as u128) * (right_denominator as u128),
+            (right_numerator as u128) * (left_denominator as u128));
+        if (a > b) COMPARE_LEFT_GREATER
+        else if (a < b) COMPARE_RIGHT_GREATER
+        else COMPARE_EQUAL
     }
 
     #[test_only]
-    public(friend) fun get_COMPARE_LEFT_GREATER(): u8 { COMPARE_LEFT_GREATER }
+    public(friend) fun get_COMPARE_LEFT_GREATER(): u8 {
+        COMPARE_LEFT_GREATER
+    }
 
     #[test_only]
-    public(friend) fun get_COMPARE_RIGHT_GREATER(): u8 { COMPARE_RIGHT_GREATER }
+    public(friend) fun get_COMPARE_RIGHT_GREATER(): u8 {
+        COMPARE_RIGHT_GREATER
+    }
 
     #[test_only]
-    public(friend) fun get_COMPARE_EQUAL(): u8 { COMPARE_EQUAL }
+    public(friend) fun get_COMPARE_EQUAL(): u8 {
+        COMPARE_EQUAL
+    }
 
     #[test]
     fun test_encode_decode() {

--- a/src/move/econia/sources/test_assets.move
+++ b/src/move/econia/sources/test_assets.move
@@ -17,49 +17,40 @@ module econia::test_assets {
 
     struct TestAssetsMetadata has key {
         base_metadata: Object<Metadata>,
-        quote_metadata: Object<Metadata>,
+        quote_metadata: Object<Metadata>
     }
 
     #[resource_group_member(group = ObjectGroup)]
     struct AssetRefs has key {
         burn_ref: BurnRef,
         mint_ref: MintRef,
-        transfer_ref: TransferRef,
+        transfer_ref: TransferRef
     }
 
-    public fun get_metadata(): (
-        Object<Metadata>,
-        Object<Metadata>,
-    ) acquires TestAssetsMetadata {
+    public fun get_metadata(): (Object<Metadata>, Object<Metadata>) acquires TestAssetsMetadata {
         ensure_assets_initialized();
         let test_assets_metadata_ref = borrow_global<TestAssetsMetadata>(@econia);
-        (
-            test_assets_metadata_ref.base_metadata,
-            test_assets_metadata_ref.quote_metadata
-        )
+        (test_assets_metadata_ref.base_metadata, test_assets_metadata_ref.quote_metadata)
     }
 
     public fun ensure_assets_initialized() {
         if (exists<TestAssetsMetadata>(@econia)) return;
         let framework = account::create_signer_for_test(@std);
-        features::change_feature_flags(&framework, vector[features::get_auids()], vector[]);
+        features::change_feature_flags(
+            &framework, vector[features::get_auids()], vector[]
+        );
         move_to(
             &account::create_signer_for_test(@econia),
             TestAssetsMetadata {
                 base_metadata: init_test_asset(BASE_SYMBOL, BASE_DECIMALS),
-                quote_metadata: init_test_asset(QUOTE_SYMBOL, QUOTE_DECIMALS),
+                quote_metadata: init_test_asset(QUOTE_SYMBOL, QUOTE_DECIMALS)
             }
         )
     }
 
     public fun burn(
-        owner: address,
-        base_amount: u64,
-        quote_amount: u64
-    ) acquires
-        AssetRefs,
-        TestAssetsMetadata
-    {
+        owner: address, base_amount: u64, quote_amount: u64
+    ) acquires AssetRefs, TestAssetsMetadata {
         ensure_assets_initialized();
         let test_assets_metadata_ref = borrow_global<TestAssetsMetadata>(@econia);
         burn_from_metadata(owner, test_assets_metadata_ref.base_metadata, base_amount);
@@ -67,13 +58,8 @@ module econia::test_assets {
     }
 
     public fun mint(
-        owner: address,
-        base_amount: u64,
-        quote_amount: u64
-    ) acquires
-        AssetRefs,
-        TestAssetsMetadata
-    {
+        owner: address, base_amount: u64, quote_amount: u64
+    ) acquires AssetRefs, TestAssetsMetadata {
         let test_assets_metadata_ref = borrow_global<TestAssetsMetadata>(@econia);
         mint_from_metadata(owner, test_assets_metadata_ref.base_metadata, base_amount);
         mint_from_metadata(owner, test_assets_metadata_ref.quote_metadata, quote_amount);
@@ -82,7 +68,7 @@ module econia::test_assets {
     public fun burn_from_metadata(
         owner: address,
         metadata: Object<Metadata>,
-        amount: u64,
+        amount: u64
     ) acquires AssetRefs {
         ensure_assets_initialized();
         let asset_refs_ref = borrow_global<AssetRefs>(object::object_address(&metadata));
@@ -92,17 +78,14 @@ module econia::test_assets {
     public fun mint_from_metadata(
         owner: address,
         metadata: Object<Metadata>,
-        amount: u64,
+        amount: u64
     ) acquires AssetRefs {
         ensure_assets_initialized();
         let asset_refs_ref = borrow_global<AssetRefs>(object::object_address(&metadata));
         primary_fungible_store::mint(&asset_refs_ref.mint_ref, owner, amount);
     }
 
-    fun init_test_asset(
-        symbol: vector<u8>,
-        decimals: u8,
-    ): Object<Metadata> {
+    fun init_test_asset(symbol: vector<u8>, decimals: u8): Object<Metadata> {
         let constructor_ref = object::create_sticky_object(@econia);
         primary_fungible_store::create_primary_store_enabled_fungible_asset(
             &constructor_ref,
@@ -111,14 +94,14 @@ module econia::test_assets {
             string::utf8(symbol),
             decimals,
             string::utf8(b""),
-            string::utf8(b""),
+            string::utf8(b"")
         );
         move_to(
             &object::generate_signer(&constructor_ref),
             AssetRefs {
                 burn_ref: fungible_asset::generate_burn_ref(&constructor_ref),
                 mint_ref: fungible_asset::generate_mint_ref(&constructor_ref),
-                transfer_ref: fungible_asset::generate_transfer_ref(&constructor_ref),
+                transfer_ref: fungible_asset::generate_transfer_ref(&constructor_ref)
             }
         );
         object::object_from_constructor_ref(&constructor_ref)


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Manually format Move files with `aptos move fmt`. Standing by for pre-commit per:

1. https://github.com/aptos-labs/aptos-core/issues/14789
1. https://github.com/movebit/movefmt/issues/39

Once these are available, new code can be added without altering legacy implementations.

# Testing

Tests pass on research packages, but not on core package because framework has changed. 

# Checklist

- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
