### PR TITLE
[ECO-2590] Add preliminary Move prover example

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -4,6 +4,7 @@ bitshift
 clmm
 collateralized
 econia
+forall
 octas
 precommit
 struct

--- a/src/move/.gitignore
+++ b/src/move/.gitignore
@@ -2,3 +2,4 @@
 **/build/*
 **/*.mvcov
 **/*.trace
+**/*.bpl

--- a/src/move/README.md
+++ b/src/move/README.md
@@ -19,3 +19,11 @@
    git ls-files | entr -c aptos move coverage bytecode --dev --move-2 \
        --module <MODULE>
    ```
+
+1. After [installing the Move Prover], to prove a package:
+
+   ```sh
+   aptos move prove --dev --move-2
+   ```
+
+[installing the move prover]: https://aptos.dev/en/build/cli/setup-cli/install-move-prover

--- a/src/move/research/prover-examples/Move.toml
+++ b/src/move/research/prover-examples/Move.toml
@@ -1,0 +1,18 @@
+[addresses]
+prover_examples = '_'
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "mainnet"
+subdir = "aptos-framework"
+
+[dev-addresses]
+prover_examples = '0xabc'
+
+[dev-dependencies]
+
+[package]
+authors = ["Econia Labs (developers@econialabs.com)"]
+name = "ProverExamples"
+upgrade_policy = "compatible"
+version = "1.0.0"

--- a/src/move/research/prover-examples/sources/main.move
+++ b/src/move/research/prover-examples/sources/main.move
@@ -1,0 +1,50 @@
+module prover_examples::main {
+
+    use std::signer;
+
+    const MAX_VALUE: u8 = 100;
+
+    /// The provided value is too high.
+    const E_VALUE_TOO_HIGH: u64 = 0;
+
+    struct PhantomKeyStruct<phantom T> has key {
+        account_address: address,
+        value: u8,
+    }
+
+    spec PhantomKeyStruct {
+        invariant value <= MAX_VALUE;
+    }
+
+    public fun move_to_phantom_key_struct<T>(account: &signer, value: u8) {
+        assert!(value <= MAX_VALUE, E_VALUE_TOO_HIGH);
+        move_to(account, PhantomKeyStruct<T> {
+            account_address: signer::address_of(account),
+            value,
+        });
+    }
+
+    public fun increment_phantom_key_struct_with_rollover<T>(account: &signer) acquires PhantomKeyStruct<T> {
+        let value_ref_mut = &mut PhantomKeyStruct<T>[signer::address_of(account)].value;
+        if (*value_ref_mut == MAX_VALUE) {
+            *value_ref_mut = 0;
+        } else {
+            *value_ref_mut += 1;
+        };
+    }
+
+    spec move_to_phantom_key_struct {
+        aborts_if value > MAX_VALUE;
+        aborts_if exists_phantom_key_struct<T>(account);
+        ensures exists_phantom_key_struct<T>(account);
+        ensures global<PhantomKeyStruct<T>>(signer::address_of(account)) == PhantomKeyStruct<T> {
+            account_address: signer::address_of(account),
+            value,
+        };
+    }
+
+    spec fun exists_phantom_key_struct<T>(account: &signer): bool {
+        exists<PhantomKeyStruct<T>>(signer::address_of(account))
+    }
+
+}

--- a/src/move/research/prover-examples/sources/main.move
+++ b/src/move/research/prover-examples/sources/main.move
@@ -16,6 +16,10 @@ module prover_examples::main {
         invariant value <= MAX_VALUE;
     }
 
+    invariant<T> forall account_address: address where exists<PhantomKeyStruct<T>>(
+        account_address
+    ): global<PhantomKeyStruct<T>>(account_address).account_address == account_address;
+
     public fun move_to_phantom_key_struct<T>(account: &signer, value: u8) {
         assert!(value <= MAX_VALUE, E_VALUE_TOO_HIGH);
         move_to(

--- a/src/move/research/prover-examples/sources/main.move
+++ b/src/move/research/prover-examples/sources/main.move
@@ -9,7 +9,7 @@ module prover_examples::main {
 
     struct PhantomKeyStruct<phantom T> has key {
         account_address: address,
-        value: u8,
+        value: u8
     }
 
     spec PhantomKeyStruct {
@@ -18,18 +18,20 @@ module prover_examples::main {
 
     public fun move_to_phantom_key_struct<T>(account: &signer, value: u8) {
         assert!(value <= MAX_VALUE, E_VALUE_TOO_HIGH);
-        move_to(account, PhantomKeyStruct<T> {
-            account_address: signer::address_of(account),
-            value,
-        });
+        move_to(
+            account,
+            PhantomKeyStruct<T> { account_address: signer::address_of(account), value }
+        );
     }
 
-    public fun increment_phantom_key_struct_with_rollover<T>(account: &signer) acquires PhantomKeyStruct<T> {
+    public fun increment_phantom_key_struct_with_rollover<T>(
+        account: &signer
+    ) acquires PhantomKeyStruct<T> {
         let value_ref_mut = &mut PhantomKeyStruct<T>[signer::address_of(account)].value;
         if (*value_ref_mut == MAX_VALUE) {
             *value_ref_mut = 0;
         } else {
-            *value_ref_mut += 1;
+            *value_ref_mut = *value_ref_mut + 1;
         };
     }
 
@@ -37,14 +39,11 @@ module prover_examples::main {
         aborts_if value > MAX_VALUE;
         aborts_if exists_phantom_key_struct<T>(account);
         ensures exists_phantom_key_struct<T>(account);
-        ensures global<PhantomKeyStruct<T>>(signer::address_of(account)) == PhantomKeyStruct<T> {
-            account_address: signer::address_of(account),
-            value,
-        };
+        ensures global<PhantomKeyStruct<T>>(signer::address_of(account))
+            == PhantomKeyStruct<T> { account_address: signer::address_of(account), value };
     }
 
     spec fun exists_phantom_key_struct<T>(account: &signer): bool {
         exists<PhantomKeyStruct<T>>(signer::address_of(account))
     }
-
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add a Move prover basic example
1. Update README to show how to run prover
1. Update gitignore to ignore Boogie files
1. Add `cspell` escape for `forall` global invariant keyword

# Testing

Follow the README, try changing function internals to trigger a fail

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)