### PR TITLE
[ECO-2367] Add Econia canonical price prototype

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 # Contribution Guidelines
 
 The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`,
-`SHOULD NOT`, `RECOMMENDED`,  `MAY`, and `OPTIONAL` in this document are to be
+`SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be
 interpreted as described in [RFC 2119].
 
 These keywords `SHALL` be in `monospace` for ease of identification.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Econia v5
+# Econia X
 
 [![pre-commit shield]][pre-commit repo]
 

--- a/cfg/README.md
+++ b/cfg/README.md
@@ -46,11 +46,11 @@ If you use `brew` on MacOS:
 You'll also need to set up your `poetry` and `pre-commit` environments for this
 repository:
 
-First ensure you're in the `econia-v5` repository at the root directory. If you
+First ensure you're in the `econia-x` repository at the root directory. If you
 haven't cloned it yet, this might look something like:
 
 ```shell
-git clone https://github.com/econia-labs/econia-v5 && cd econia-v5
+git clone https://github.com/econia-labs/econia-x && cd econia-x
 ```
 
 Then install the Python hooks `poetry` dependencies:

--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -7,6 +7,7 @@ econia
 forall
 octas
 precommit
+significand
 struct
 structs
 subdir

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -1,5 +1,10 @@
-# cspell:words autofix, markdownlint, mdformat, shfmt, autoflake, Autoflake
-# cspell:words isort, mypy, Mypy
+# cspell:word autofix
+# cspell:word autoflake
+# cspell:word isort
+# cspell:word markdownlint
+# cspell:word mdformat
+# cspell:word shfmt
+# cspell:word mypy
 ---
 repos:
 -
@@ -112,9 +117,11 @@ repos:
   hooks:
   - additional_dependencies:
     - 'mdformat-gfm'
+    - 'mdformat-frontmatter'
+    - 'mdformat-myst'
     id: 'mdformat'
   repo: 'https://github.com/executablebooks/mdformat'
-  rev: '0.7.17'
+  rev: '0.7.21'
 -
   hooks:
   -

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # cspell:word autofix
 # cspell:word autoflake
 # cspell:word isort
+# cspell:word frontmatter
 # cspell:word markdownlint
 # cspell:word mdformat
 # cspell:word shfmt

--- a/doc/architecture-specification.md
+++ b/doc/architecture-specification.md
@@ -1,6 +1,6 @@
 <!--- cspell:words evictable, incentivized -->
 
-# Econia v5 Architecture Specification
+# Econia X Architecture Specification
 
 The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`,
 `SHOULD NOT`, `RECOMMENDED`,  `MAY`, and `OPTIONAL` in this document are to be

--- a/doc/architecture-specification.md
+++ b/doc/architecture-specification.md
@@ -3,7 +3,7 @@
 # Econia X Architecture Specification
 
 The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`,
-`SHOULD NOT`, `RECOMMENDED`,  `MAY`, and `OPTIONAL` in this document are to be
+`SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be
 interpreted as described in [RFC 2119].
 
 These keywords `SHALL` be in `monospace` for ease of identification.

--- a/src/move/README.md
+++ b/src/move/README.md
@@ -8,7 +8,7 @@
 
    ```sh
    git ls-files | entr -c sh -c " \
-       aptos move test --dev --move-2 --coverage &&
+       aptos move test --dev --coverage &&
        aptos move fmt
    "
    ```
@@ -16,14 +16,14 @@
 1. Display coverage against bytecode on file change:
 
    ```sh
-   git ls-files | entr -c aptos move coverage bytecode --dev --move-2 \
+   git ls-files | entr -c aptos move coverage bytecode --dev \
        --module <MODULE>
    ```
 
 1. After [installing the Move Prover], to prove a package:
 
    ```sh
-   aptos move prove --dev --move-2 --trace
+   aptos move prove --dev --trace
    ```
 
 [installing the move prover]: https://aptos.dev/en/build/cli/setup-cli/install-move-prover

--- a/src/move/research/price/Move.toml
+++ b/src/move/research/price/Move.toml
@@ -1,0 +1,18 @@
+[addresses]
+price = '_'
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "mainnet"
+subdir = "aptos-framework"
+
+[dev-addresses]
+price = '0xabc'
+
+[dev-dependencies]
+
+[package]
+authors = ["Econia Labs (developers@econialabs.com)"]
+name = "Price"
+upgrade_policy = "compatible"
+version = "0.1.0"

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -1,0 +1,61 @@
+# Price
+
+## General
+
+This implementation defines price as an unsigned floating point decimal, using a
+`u32` encoding schema that canonicalizes all representable numbers to ensure a
+strict total order:
+
+| Bits | Encoded data | Symbol |
+|-|-|-|
+| 0—26 | Significand | $s$ |
+| 27—31 | Exponent | $e$ |
+
+Hence a price $p$ is taken as:
+
+$$p = s \cdot 10^{e}$$
+
+## Significant digits
+
+With 27 bits, the significand can theoretically encode any natural number $n$
+for $0 \leq n \leq 2^{27} - 1 = 134217727$.
+
+However in practice, a given significand $s$ is bounded between
+$s_{min} = 100000000 = 10^8$ and $s_{max} = 999999999 \approx 10^9$
+($s_{min} \leq s \leq s_{max}$), to ensure a canonical encoding for any given
+representable number. For example the number $1.5$ is represented as
+$1.5 = 150000000 \cdot 10^{-8}$.
+
+## Bias derivation
+
+With 5 bits, the exponent can theoretically encode any natural number $n$ for
+$0 \leq n \leq 2^5 - 1 = 31$.
+
+However in practice, due to the bounds on $s_{min}$ and $s_{max}$, negative
+exponents are required to represent numbers smaller than $s_{min}$, like $1.5$.
+
+Hence for a given significand $s$, there are thus 32 possible prices ranging
+from $s \cdot 10 ^ {e_{min}}$ to $s \cdot 10 ^ {e_{max}}$ across different
+orders of magnitude.
+
+Note that any significand can be represented as
+$s = a \cdot s_{min} = a \cdot 10^8$, thus converting it to normalized
+scientific notation for $1 \leq a \lt 10$. Hence the range of prices for any
+given significand $s$ resolves to a lower bound of $a \cdot 10 ^ {8 + e_{min}}$
+and an upper bound of $a \cdot 10 ^ {8 + e_{max}}$.
+
+Given the number of bits allowed, ensuring adequate range across both positive
+and negative exponents requires solving the system of equations:
+
+$$8 + e_{min} = -(8 + e_{max})$$
+
+$$e_{max} - e_{min} = 31$$
+
+The solution $e_{max} = 7.5, e_{min} = -23.5$, however, does not yield integers,
+so the results are rounded to $e_{max} = 8, e_{min}=-23$, resulting in an
+effective price range (scientific notation) between $a \cdot 10^{-15}$ and
+$a \cdot 10^{16}$. This is consistent with the [IEE 754 standard], which defines
+exponent ranges between $-126$ and $+127$, $-1022$ and $+1023$, and so on
+(`emin = 1 - emax`).
+
+[IEE 754 standard]: https://en.wikipedia.org/wiki/IEEE_754

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -33,6 +33,13 @@ $$
 p = m \cdot 10^n
 $$
 
+The minimum and maximum representable nonzero prices are thus:
+
+| Extrema | Symbol    | Value                     |
+| ------- | --------- | ------------------------- |
+| Minimum | $p_{min}$ | $1 \cdot 10^{-16}$        |
+| Maximum | $p_{max}$ | $9.9999999 \cdot 10^{15}$ |
+
 ## Encoding
 
 The 27 significand bits can theoretically encode any natural number $n$ for
@@ -86,18 +93,18 @@ exponents. Since $n=0$ exhausts one representable exponent, the selection of a
 symmetric range across different orders of magnitude requires choosing between
 two options:
 
-| Option | Lower bound     | Upper bound     | Range                   |
-| ------ | --------------- | --------------- | ----------------------- |
-| 1      | $n_{min} = -16$ | $n_{max} = +15$ | $ -16 \leq n \leq +15 $ |
-| 2      | $n_{min} = -15$ | $n_{max} = +16$ | $ -15 \leq n \leq +16 $ |
+| Option | Lower bound     | Upper bound     | Range                 |
+| ------ | --------------- | --------------- | --------------------- |
+| 1      | $n_{min} = -16$ | $n_{max} = +15$ | $-16 \leq n \leq +15$ |
+| 2      | $n_{min} = -15$ | $n_{max} = +16$ | $-15 \leq n \leq +16$ |
 
 To simplify the decision making process, consider an analogous 2-bit exponent
 with options A and B:
 
-| Option | Lower bound    | Upper bound    | Range                 |
-| ------ | -------------- | -------------- | --------------------- |
-| A      | $n_{min} = -2$ | $n_{max} = +1$ | $ -2 \leq n \leq +1 $ |
-| B      | $n_{min} = -1$ | $n_{max} = +2$ | $ -1 \leq n \leq +2 $ |
+| Option | Lower bound    | Upper bound    | Range               |
+| ------ | -------------- | -------------- | ------------------- |
+| A      | $n_{min} = -2$ | $n_{max} = +1$ | $-2 \leq n \leq +1$ |
+| B      | $n_{min} = -1$ | $n_{max} = +2$ | $-1 \leq n \leq +2$ |
 
 Now consider the lowest possible significand $m_{min} = 1.0$ and the highest
 possible significand $m_{max} = 9.99$ (for 3 significant digits). For option A:
@@ -115,10 +122,10 @@ And for option B:
 
 <!-- markdownlint-disable MD013 -->
 
-|                      | Smallest exponent                       | Largest exponent                       |
-| -------------------- | --------------------------------------- | -------------------------------------- |
-| Smallest significand | $1.00 \cdot 10^{-1} = 0.1$              | $1.00 \cdot 10^{2} = 100$              |
-| Largest significand  | $9.99 \cdot 10^{-1} = 0.999 \approx 1 $ | $9.99 \cdot 10^{2} = 999 \approx 1000$ |
+|                      | Smallest exponent                      | Largest exponent                       |
+| -------------------- | -------------------------------------- | -------------------------------------- |
+| Smallest significand | $1.00 \cdot 10^{-1} = 0.1$             | $1.00 \cdot 10^{2} = 100$              |
+| Largest significand  | $9.99 \cdot 10^{-1} = 0.999 \approx 1$ | $9.99 \cdot 10^{2} = 999 \approx 1000$ |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -140,8 +147,8 @@ Option A ($|n_{min}| = |n_{max}| + 1$) presents several advantages:
 Hence option A is the more practical choice, and by extension for the current
 implementation, option 1, which also has $|n_{min}| = |n_{max}| + 1$:
 
-| Lower bound     | Upper bound     | Range                   |
-| --------------- | --------------- | ----------------------- |
-| $n_{min} = -16$ | $n_{max} = +15$ | $ -16 \leq n \leq +15 $ |
+| Lower bound     | Upper bound     | Range                 |
+| --------------- | --------------- | --------------------- |
+| $n_{min} = -16$ | $n_{max} = +15$ | $-16 \leq n \leq +15$ |
 
 [normalized number]: https://en.wikipedia.org/wiki/Normalized_number

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -1,5 +1,3 @@
-<!--- cspell:word-->
-
 # Price
 
 ## General
@@ -66,18 +64,16 @@ Thus, the price $987 = 9.87 \cdot 10^2$ is encoded as follows:
 
 <!-- markdownlint-disable MD013 -->
 
-| Symbol | Description         | Encoded value                  | Bits                          |
-| ------ | ------------------- | ------------------------------ | ----------------------------- |
-| $m_e$  | Encoded significand | $9.87 \cdot 10^7 = 98,700,000$ | `101111000100000101011100000` |
-| $n_e$  | Encoded exponent    | $2 + 16 = 18$                  | `10010`                       |
+| Description         | Symbol | Encoded value                  | Bits                          |
+| ------------------- | ------ | ------------------------------ | ----------------------------- |
+| Encoded significand | $m_e$  | $9.87 \cdot 10^7 = 98,700,000$ | `101111000100000101011100000` |
+| Encoded exponent    | $n_e$  | $2 + 16 = 18$                  | `10010`                       |
 
 <!-- markdownlint-enable MD013 -->
 
-> ```
->               10010101111000100000101011100000
-> exponent bits ^^^^^
->                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ significand bits
-> ```
+>                   10010101111000100000101011100000
+>     exponent bits ^^^^^
+>                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ significand bits
 
 ## Exponent range selection
 

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -71,9 +71,11 @@ Thus, the price $987 = 9.87 \cdot 10^2$ is encoded as follows:
 
 <!-- markdownlint-enable MD013 -->
 
->                   10010101111000100000101011100000
->     exponent bits ^^^^^
->                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ significand bits
+> ```txt
+>               10010101111000100000101011100000
+> exponent bits ^^^^^
+>                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ significand bits
+> ```
 
 ## Exponent range selection
 

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -20,10 +20,10 @@ $$
 The chosen `u32` format ensures a canonical encoding of any representable
 number, resulting in a strict total order:
 
-| Bits | Encoded data | Symbol |
-|-|-|-|
-| 0—26 | Significand | $m$ |
-| 27—31 | Exponent | $n$ |
+| Bits  | Encoded data | Symbol |
+| ----- | ------------ | ------ |
+| 0—26  | Significand  | $m$    |
+| 27—31 | Exponent     | $n$    |
 
 Hence for a normalized significand $1 \leq m < 10$, price $p$ is denoted:
 
@@ -74,5 +74,5 @@ $a \cdot 10^{16}$. This is consistent with the [IEE 754 standard], which defines
 exponent ranges between $-126$ and $+127$, $-1022$ and $+1023$, and so on
 (`emin = 1 - emax`).
 
-[IEE 754 standard]: https://en.wikipedia.org/wiki/IEEE_754
+[iee 754 standard]: https://en.wikipedia.org/wiki/IEEE_754
 [normalized number]: https://en.wikipedia.org/wiki/Normalized_number

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -1,4 +1,4 @@
-# Price
+# Econia canonical price
 
 ## General
 

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -2,8 +2,8 @@
 
 ## General
 
-This implementation defines price $p$ as the ratio of a quote asset $q$ to a
-base asset $b$:
+This implementation defines price $p$ as the ratio of quote asset indivisible
+subunits $q$ to base asset indivisible subunits $b$:
 
 $$
 p = \frac{q}{b}
@@ -128,7 +128,7 @@ Option A ($|n_{min}| = |n_{max}| + 1$) presents several advantages:
    $p_{min} = m_{min} \cdot 10^{n_{min}} = 0.01$ straddles the number $1$ by two
    orders of magnitude, as does the largest representable number,
    $p_{max} = m_{max} \cdot 10^{n_{max}} \approx 100$. This contrast with option
-   B where $p_min = 0.1$ is 1 order less but $p_{max} \approx 1000$ is
+   B where $p_{min} = 0.1$ is 1 order less but $p_{max} \approx 1000$ is
    (approximately) 3 more.
 1. In option B for the largest significand $m_{max} = 9.99$, the smallest
    representable number $m_{max} \cdot 10 ^ {n_{min}} = 0.999 \approx 1$ is
@@ -137,7 +137,7 @@ Option A ($|n_{min}| = |n_{max}| + 1$) presents several advantages:
    orders of magnitude above $1$. This asymmetric arrangement impractical, with
    effectively no dynamic range below $1$.
 
-Hence option A is the more practical choice, and by extension for the given
+Hence option A is the more practical choice, and by extension for the current
 implementation, option 1, which also has $|n_{min}| = |n_{max}| + 1$:
 
 | Lower bound     | Upper bound     | Range                   |

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -11,7 +11,9 @@ $$
 
 Prices are denoted using an unsigned [normalized number] format, so at current
 market prices as of the time of this writing, for example, the ratio of $9.79$
-`USD` per $1$ `APT` would be denoted $p = 9.79 \cdot 10^1$:
+`USD` per $1$ `APT` would be denoted $p = 9.79 \cdot 10^1$. (This example
+assumes a hypothetical `USD` asset with the same number of `Coin` decimals as
+`APT`, since the implementation operates on indivisible subunits).
 
 $$
 p = \frac{9.79}{1} = 9.79 \cdot 10^1
@@ -77,7 +79,7 @@ Thus, the price $987 = 9.87 \cdot 10^2$ is encoded as follows:
 >                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ significand bits
 > ```
 
-## Exponent range selection
+## Appendix: exponent range selection
 
 With 5 `u32` bits allocated for $n_e$, there are thus $2^5 = 32$ possible
 exponents. Since $n=0$ exhausts one representable exponent, the selection of a

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -2,18 +2,34 @@
 
 ## General
 
-This implementation defines price as an unsigned floating point decimal, using a
-`u32` encoding schema that canonicalizes all representable numbers to ensure a
-strict total order:
+This implementation defines price $p$ as the ratio of a quote asset $q$ to a
+base asset $b$:
+
+$$
+p = \frac{q}{b}
+$$
+
+Prices are denoted using an unsigned [normalized number] format, so at current
+market prices as of the time of this writing, for example, the ratio of 9.79
+`USD` per 1 `APT` would be denoted $p = 9.79 \cdot 10^1$:
+
+$$
+p = \frac{9.79}{1} = 9.79 \cdot 10^1
+$$
+
+The chosen `u32` format ensures a canonical encoding of any representable
+number, resulting in a strict total order:
 
 | Bits | Encoded data | Symbol |
 |-|-|-|
-| 0—26 | Significand | $s$ |
-| 27—31 | Exponent | $e$ |
+| 0—26 | Significand | $m$ |
+| 27—31 | Exponent | $n$ |
 
-Hence a price $p$ is taken as:
+Hence for a normalized significand $1 \leq m < 10$, price $p$ is denoted:
 
-$$p = s \cdot 10^{e}$$
+$$
+p = m \cdot 10^n
+$$
 
 ## Significant digits
 
@@ -59,3 +75,4 @@ exponent ranges between $-126$ and $+127$, $-1022$ and $+1023$, and so on
 (`emin = 1 - emax`).
 
 [IEE 754 standard]: https://en.wikipedia.org/wiki/IEEE_754
+[normalized number]: https://en.wikipedia.org/wiki/Normalized_number

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -456,10 +456,14 @@ module price::price {
     }
 
     #[test]
+    #[expected_failure(abort_code = E_LOG_0_UNDEFINED)]
+    public fun test_floored_log_10_with_max_power_leq_log_0_undefined() {
+        floored_log_10_with_max_power_leq(0);
+    }
+
+    #[test]
     public fun test_price() {
         // Price 1.25 * 10^7
-        // Base = 23_587
-        // Quote = 294_837_500_000
         let base = 23_587;
         let quote = 294_837_500_000;
         let price = price(base, quote);
@@ -467,8 +471,6 @@ module price::price {
         assert!(encoded_price(price) == 12_500_000);
 
         // Price 8.7654321 * 10^-12
-        // Base = 10_000_000_000_000_000_000
-        // Quote = 87_654_321
         base = 10_000_000_000_000_000_000;
         quote = 87_654_321;
         price = price(base, quote);
@@ -476,8 +478,6 @@ module price::price {
         assert!(encoded_price(price) == 87_654_321);
 
         // Price 5.0000000 * 10^-16
-        // Base = 2_000_000_000_000_000_000
-        // Quote = 1_000
         base = 2_000_000_000_000_000_000;
         quote = 1_000;
         price = price(base, quote);
@@ -485,8 +485,6 @@ module price::price {
         assert!(encoded_price(price) == 50_000_000);
 
         // Price 9.9999999 * 10^15
-        // Base = 1_000
-        // Quote = 9_999_999_900_000_000_000
         base = 1_000;
         quote = 9_999_999_900_000_000_000;
         price = price(base, quote);
@@ -494,13 +492,41 @@ module price::price {
         assert!(encoded_price(price) == 99_999_999);
 
         // Price 1.0000000 * 10^-16
-        // Base = 2_000_000_000_000_000_000
-        // Quote = 200
         base = 2_000_000_000_000_000_000;
         quote = 200;
         price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 - 16);
         assert!(encoded_price(price) == 10_000_000);
 
+        // Price 9.7900000 * 10^1
+        base = 2_000_000;
+        quote = 195_800_000;
+        price = price(base, quote);
+        assert!(encoded_exponent(price) == N_16 + 1);
+        assert!(encoded_price(price) == 97_900_000);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_BASE_ZERO)]
+    public fun test_price_base_zero() {
+        price(0, 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_TOO_LARGE_TO_REPRESENT)]
+    public fun test_price_too_large_to_represent() {
+        // Price 9.9999999 * 10^16
+        let base = 100;
+        let quote = 9_999_999_900_000_000_000;
+        price(base, quote);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_TOO_SMALL_TO_REPRESENT)]
+    public fun test_price_too_small_to_represent() {
+        // Price 1.0000000 * 10^-17
+        let base = 2_000_000_000_000_000_000;
+        let quote = 20;
+        price(base, quote);
     }
 }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -2,15 +2,15 @@ module price::price {
 
     /// The largest power of 10 that can fit in a `u64`, as a `u128`.
     /// In Python: `f"{10 ** (math.floor(math.log10(2 ** 64 - 1))):_}"`
-    const DEC_MAX_U64_AS_U128: u128 = 10_000_000_000_000_000_000;
+    const DEC_MAX_U64_AS: u128 = 10_000_000_000_000_000_000;
     /// The exponent of the largest power of 10 that can fit in a `u64`.
     /// In Python: `math.floor(math.log10(2 ** 64 - 1))`
     const EXP_MAX_U64: u32 = 19;
     /// The exponent of the largest power of 10 that can fit in a `u128`.
     /// In Python: `math.floor(math.log10(2 ** 128 - 1))`
-    const EXP_MAX_U128: u32 = 38;
+    const EXP_MAX: u32 = 38;
     /// The largest `u128` value. In Python: `f"{2 ** 128 - 1:_}"`
-    const U128_MAX: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
+    const MAX_U128: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
     /// The bias for the exponent of the canonical price encoding, which is the minimum exponent
     /// that can be represented when taken as a negative number.
     const EXPONENT_BIAS: u32 = 16;
@@ -19,45 +19,45 @@ module price::price {
     /// Decimal conversion factor to convert normalized significand to canonical price encoding.
     const SIGNIFICAND_CONVERSION_SHIFT: u32 = 7;
 
-    const E_0_U128: u128 = 1;
-    const E_1_U128: u128 = 10;
-    const E_2_U128: u128 = 100;
-    const E_3_U128: u128 = 1_000;
-    const E_4_U128: u128 = 10_000;
-    const E_5_U128: u128 = 100_000;
-    const E_6_U128: u128 = 1_000_000;
-    const E_7_U128: u128 = 10_000_000;
-    const E_8_U128: u128 = 100_000_000;
-    const E_9_U128: u128 = 1_000_000_000;
-    const E_10_U128: u128 = 10_000_000_000;
-    const E_11_U128: u128 = 100_000_000_000;
-    const E_12_U128: u128 = 1_000_000_000_000;
-    const E_13_U128: u128 = 10_000_000_000_000;
-    const E_14_U128: u128 = 100_000_000_000_000;
-    const E_15_U128: u128 = 1_000_000_000_000_000;
-    const E_16_U128: u128 = 10_000_000_000_000_000;
-    const E_17_U128: u128 = 100_000_000_000_000_000;
-    const E_18_U128: u128 = 1_000_000_000_000_000_000;
-    const E_19_U128: u128 = 10_000_000_000_000_000_000;
-    const E_20_U128: u128 = 100_000_000_000_000_000_000;
-    const E_21_U128: u128 = 1_000_000_000_000_000_000_000;
-    const E_22_U128: u128 = 10_000_000_000_000_000_000_000;
-    const E_23_U128: u128 = 100_000_000_000_000_000_000_000;
-    const E_24_U128: u128 = 1_000_000_000_000_000_000_000_000;
-    const E_25_U128: u128 = 10_000_000_000_000_000_000_000_000;
-    const E_26_U128: u128 = 100_000_000_000_000_000_000_000_000;
-    const E_27_U128: u128 = 1_000_000_000_000_000_000_000_000_000;
-    const E_28_U128: u128 = 10_000_000_000_000_000_000_000_000_000;
-    const E_29_U128: u128 = 100_000_000_000_000_000_000_000_000_000;
-    const E_30_U128: u128 = 1_000_000_000_000_000_000_000_000_000_000;
-    const E_31_U128: u128 = 10_000_000_000_000_000_000_000_000_000_000;
-    const E_32_U128: u128 = 100_000_000_000_000_000_000_000_000_000_000;
-    const E_33_U128: u128 = 1_000_000_000_000_000_000_000_000_000_000_000;
-    const E_34_U128: u128 = 10_000_000_000_000_000_000_000_000_000_000_000;
-    const E_35_U128: u128 = 100_000_000_000_000_000_000_000_000_000_000_000;
-    const E_36_U128: u128 = 1_000_000_000_000_000_000_000_000_000_000_000_000;
-    const E_37_U128: u128 = 10_000_000_000_000_000_000_000_000_000_000_000_000;
-    const E_38_U128: u128 = 100_000_000_000_000_000_000_000_000_000_000_000_000;
+    const E_0: u128 = 1;
+    const E_1: u128 = 10;
+    const E_2: u128 = 100;
+    const E_3: u128 = 1_000;
+    const E_4: u128 = 10_000;
+    const E_5: u128 = 100_000;
+    const E_6: u128 = 1_000_000;
+    const E_7: u128 = 10_000_000;
+    const E_8: u128 = 100_000_000;
+    const E_9: u128 = 1_000_000_000;
+    const E_10: u128 = 10_000_000_000;
+    const E_11: u128 = 100_000_000_000;
+    const E_12: u128 = 1_000_000_000_000;
+    const E_13: u128 = 10_000_000_000_000;
+    const E_14: u128 = 100_000_000_000_000;
+    const E_15: u128 = 1_000_000_000_000_000;
+    const E_16: u128 = 10_000_000_000_000_000;
+    const E_17: u128 = 100_000_000_000_000_000;
+    const E_18: u128 = 1_000_000_000_000_000_000;
+    const E_19: u128 = 10_000_000_000_000_000_000;
+    const E_20: u128 = 100_000_000_000_000_000_000;
+    const E_21: u128 = 1_000_000_000_000_000_000_000;
+    const E_22: u128 = 10_000_000_000_000_000_000_000;
+    const E_23: u128 = 100_000_000_000_000_000_000_000;
+    const E_24: u128 = 1_000_000_000_000_000_000_000_000;
+    const E_25: u128 = 10_000_000_000_000_000_000_000_000;
+    const E_26: u128 = 100_000_000_000_000_000_000_000_000;
+    const E_27: u128 = 1_000_000_000_000_000_000_000_000_000;
+    const E_28: u128 = 10_000_000_000_000_000_000_000_000_000;
+    const E_29: u128 = 100_000_000_000_000_000_000_000_000_000;
+    const E_30: u128 = 1_000_000_000_000_000_000_000_000_000_000;
+    const E_31: u128 = 10_000_000_000_000_000_000_000_000_000_000;
+    const E_32: u128 = 100_000_000_000_000_000_000_000_000_000_000;
+    const E_33: u128 = 1_000_000_000_000_000_000_000_000_000_000_000;
+    const E_34: u128 = 10_000_000_000_000_000_000_000_000_000_000_000;
+    const E_35: u128 = 100_000_000_000_000_000_000_000_000_000_000_000;
+    const E_36: u128 = 1_000_000_000_000_000_000_000_000_000_000_000_000;
+    const E_37: u128 = 10_000_000_000_000_000_000_000_000_000_000_000_000;
+    const E_38: u128 = 100_000_000_000_000_000_000_000_000_000_000_000_000;
 
     /// Base term is 0.
     const E_BASE_ZERO: u64 = 1;
@@ -73,8 +73,9 @@ module price::price {
     public fun price(base: u64, quote: u64): u32 {
         assert!(base > 0, E_BASE_ZERO);
 
-        let ratio_scaled = ((quote as u128) * DEC_MAX_U64_AS_U128) / (base as u128);
-        let (log_10_ratio_scaled, last_power_of_10_scaled) = floored_log_10(ratio_scaled);
+        let ratio_scaled = ((quote as u128) * DEC_MAX_U64_AS) / (base as u128);
+        let (log_10_ratio_scaled, last_power_of_10_scaled) =
+            floored_log_10_with_power(ratio_scaled);
 
         // The base-10 logarithm of the ratio must be at least the minimum allowable exponent after
         // scaling back down:
@@ -87,191 +88,199 @@ module price::price {
             E_TOO_SMALL_TO_REPRESENT
         );
 
-        // At this point, ratio_scaled could be as small as E_3_U128 = 1_000, which scales back down
+        // At this point, ratio_scaled could be as small as E_3 = 1_000, which scales back down
         // to 1_000 * 10^-19 = 1 * 10^-16, which is the smallest value that can be represented.
         // Hence extracting the significand may require padding or truncating. If less than
-        // E_7_U128, will need to pad, and if greater than E_7_U128, will need to truncate. If
-        // truncating, can divide by (last_power_of_10_scaled / E_7_U128) to get the significand.
+        // E_7, will need to pad, and if greater than E_7, will need to truncate. If
+        // truncating, can divide by (last_power_of_10_scaled / E_7) to get the significand.
         //
         // In either case, the encoded exponent must be corrected for the shift amount.
         let (significand_encoded, exponent_encoded) =
-            if (last_power_of_10_scaled < E_7_U128) { // 3 <= n < 7.
+            if (last_power_of_10_scaled < E_7) { // 3 <= n < 7.
                 let (pad_multiplier, exponent_shift) =
-                    if (last_power_of_10_scaled < E_5_U128) { // 3 <= n < 5.
-                        if (last_power_of_10_scaled < E_4_U128) { // 3 <= n < 4.
-                            (E_4_U128, 4)
+                    if (last_power_of_10_scaled < E_5) { // 3 <= n < 5.
+                        if (last_power_of_10_scaled < E_4) { // 3 <= n < 4.
+                            (E_4, 4)
                         } else { // 4 <= n < 5.
-                            (E_3_U128, 3)
+                            (E_3, 3)
                         }
                     } else { // 5 <= n < 7.
-                        if (last_power_of_10_scaled < E_6_U128) { // 5 <= n < 6.
-                            (E_2_U128, 2)
+                        if (last_power_of_10_scaled < E_6) { // 5 <= n < 6.
+                            (E_2, 2)
                         } else { // 6 <= n < 7.
-                            (E_1_U128, 1)
+                            (E_1, 1)
                         }
                     };
                 ((ratio_scaled * pad_multiplier),
                 log_10_ratio_scaled + exponent_shift + EXPONENT_BIAS
                     - SIGNIFICAND_CONVERSION_SHIFT)
             } else {
-                (ratio_scaled / (last_power_of_10_scaled / E_7_U128), 42)
+                (ratio_scaled / (last_power_of_10_scaled / E_7), 42)
             };
         1
     }
 
     #[view]
-    /// Return the floored base-10 logarithm of `value` and 10 raised to that power. Uses binary
-    /// search for speed, with each new branch of the tree testing at the floored midpoint of the
-    /// previous branch.
-    public fun floored_log_10(value: u128): (u32, u128) {
+    /// Returns the floored base-10 logarithm of `value`, and 10 raised to that power.
+    ///
+    /// The algorithm uses a binary search for speed, with each new branch of the search bisecting
+    /// the remaining range of possible values.
+    ///
+    /// Since the largest power of then that can fit in a `u128` is `10^38`, the search range begins
+    /// as `0 <= n < 39`. Then the search range is bisected about the floored average of the
+    /// endpoints: `(0 + 39) / 2 = 19`. This process yields two branches: `0 <= n < 19` and
+    /// `19 <= n < 39`. The bisection process is repeated until the range is narrowed to a single
+    /// value, terminating the search.
+    public fun floored_log_10_with_power(value: u128): (u32, u128) {
         assert!(value > 0, E_LOG_0_UNDEFINED);
-        if (value < E_19_U128) { // 0 <= n < 19.
-            if (value < E_9_U128) { // 0 <= n < 9.
-                if (value < E_4_U128) { // 0 <= n < 4.
-                    if (value < E_2_U128) { // 0 <= n < 2.
-                        if (value < E_1_U128) { // 0 <= n < 1.
-                            (0, E_0_U128)
+        // 0 <= n < 39.
+        if (value < E_19) { // 0 <= n < 19.
+            if (value < E_9) { // 0 <= n < 9.
+                if (value < E_4) { // 0 <= n < 4.
+                    if (value < E_2) { // 0 <= n < 2.
+                        if (value < E_1) { // 0 <= n < 1.
+                            (0, E_0)
                         } else {
-                            (1, E_1_U128)
+                            (1, E_1)
                         }
                     } else { // 2 <= n < 4.
-                        if (value < E_3_U128) { // 2 <= n < 3.
-                            (2, E_2_U128)
+                        if (value < E_3) { // 2 <= n < 3.
+                            (2, E_2)
                         } else {
-                            (3, E_3_U128)
+                            (3, E_3)
                         }
                     }
                 } else { // 4 <= n < 9.
-                    if (value < E_6_U128) { // 4 <= n < 6.
-                        if (value < E_5_U128) { // 4 <= n < 5.
-                            (4, E_4_U128)
+                    if (value < E_6) { // 4 <= n < 6.
+                        if (value < E_5) { // 4 <= n < 5.
+                            (4, E_4)
                         } else {
-                            (5, E_5_U128)
+                            (5, E_5)
                         }
                     } else { // 6 <= n < 9.
-                        if (value < E_7_U128) { // 6 <= n < 7.
-                            (6, E_6_U128)
+                        if (value < E_7) { // 6 <= n < 7.
+                            (6, E_6)
                         } else { // 7 <= n < 9.
-                            if (value < E_8_U128) { // 7 <= n < 8.
-                                (7, E_7_U128)
+                            if (value < E_8) { // 7 <= n < 8.
+                                (7, E_7)
                             } else {
-                                (8, E_8_U128)
+                                (8, E_8)
                             }
                         }
                     }
                 }
             } else { // 9 <= n < 19.
-                if (value < E_14_U128) { // 9 <= n < 14.
-                    if (value < E_11_U128) { // 9 <= n < 11.
-                        if (value < E_10_U128) { // 9 <= n < 10.
-                            (9, E_9_U128)
+                if (value < E_14) { // 9 <= n < 14.
+                    if (value < E_11) { // 9 <= n < 11.
+                        if (value < E_10) { // 9 <= n < 10.
+                            (9, E_9)
                         } else {
-                            (10, E_10_U128)
+                            (10, E_10)
                         }
                     } else { // 11 <= n < 14.
-                        if (value < E_12_U128) { // 11 <= n < 12.
-                            (11, E_11_U128)
+                        if (value < E_12) { // 11 <= n < 12.
+                            (11, E_11)
                         } else {
-                            if (value < E_13_U128) { // 12 <= n < 13.
-                                (12, E_12_U128)
+                            if (value < E_13) { // 12 <= n < 13.
+                                (12, E_12)
                             } else {
-                                (13, E_13_U128)
+                                (13, E_13)
                             }
                         }
                     }
                 } else { // 14 <= n < 19.
-                    if (value < E_16_U128) { // 14 <= n < 16.
-                        if (value < E_15_U128) { // 14 <= n < 15.
-                            (14, E_14_U128)
+                    if (value < E_16) { // 14 <= n < 16.
+                        if (value < E_15) { // 14 <= n < 15.
+                            (14, E_14)
                         } else {
-                            (15, E_15_U128)
+                            (15, E_15)
                         }
                     } else { // 16 <= n < 19.
-                        if (value < E_17_U128) { // 16 <= n < 17.
-                            (16, E_16_U128)
+                        if (value < E_17) { // 16 <= n < 17.
+                            (16, E_16)
                         } else { // 17 <= n < 19.
-                            if (value < E_18_U128) { // 17 <= n < 18.
-                                (17, E_17_U128)
+                            if (value < E_18) { // 17 <= n < 18.
+                                (17, E_17)
                             } else {
-                                (18, E_18_U128)
+                                (18, E_18)
                             }
                         }
                     }
                 }
             }
         } else { // 19 <= n < 39.
-            if (value < E_29_U128) { // 19 <= n < 29.
-                if (value < E_24_U128) { // 19 <= n < 24.
-                    if (value < E_21_U128) { // 19 <= n < 21.
-                        if (value < E_20_U128) { // 19 <= n < 20.
-                            (19, E_19_U128)
+            if (value < E_29) { // 19 <= n < 29.
+                if (value < E_24) { // 19 <= n < 24.
+                    if (value < E_21) { // 19 <= n < 21.
+                        if (value < E_20) { // 19 <= n < 20.
+                            (19, E_19)
                         } else {
-                            (20, E_20_U128)
+                            (20, E_20)
                         }
                     } else { // 21 <= n < 24.
-                        if (value < E_22_U128) { // 21 <= n < 22.
-                            (21, E_21_U128)
+                        if (value < E_22) { // 21 <= n < 22.
+                            (21, E_21)
                         } else { // 22 <= n < 24.
-                            if (value < E_23_U128) { // 22 <= n < 23.
-                                (22, E_22_U128)
+                            if (value < E_23) { // 22 <= n < 23.
+                                (22, E_22)
                             } else {
-                                (23, E_23_U128)
+                                (23, E_23)
                             }
                         }
                     }
                 } else { // 24 <= n < 29.
-                    if (value < E_26_U128) { // 24 <= n < 26.
-                        if (value < E_25_U128) { // 24 <= n < 25.
-                            (24, E_24_U128)
+                    if (value < E_26) { // 24 <= n < 26.
+                        if (value < E_25) { // 24 <= n < 25.
+                            (24, E_24)
                         } else {
-                            (25, E_25_U128)
+                            (25, E_25)
                         }
                     } else { // 26 <= n < 29.
-                        if (value < E_27_U128) { // 26 <= n < 27.
-                            (26, E_26_U128)
+                        if (value < E_27) { // 26 <= n < 27.
+                            (26, E_26)
                         } else { // 27 <= n < 29.
-                            if (value < E_28_U128) { // 27 <= n < 28.
-                                (27, E_27_U128)
+                            if (value < E_28) { // 27 <= n < 28.
+                                (27, E_27)
                             } else {
-                                (28, E_28_U128)
+                                (28, E_28)
                             }
                         }
                     }
                 }
             } else { // 29 <= n < 39.
-                if (value < E_34_U128) { // 29 <= n < 34.
-                    if (value < E_31_U128) { // 29 <= n < 31.
-                        if (value < E_30_U128) { // 29 <= n < 30.
-                            (29, E_29_U128)
+                if (value < E_34) { // 29 <= n < 34.
+                    if (value < E_31) { // 29 <= n < 31.
+                        if (value < E_30) { // 29 <= n < 30.
+                            (29, E_29)
                         } else {
-                            (30, E_30_U128)
+                            (30, E_30)
                         }
                     } else { // 31 <= n < 34.
-                        if (value < E_32_U128) { // 31 <= n < 32.
-                            (31, E_31_U128)
+                        if (value < E_32) { // 31 <= n < 32.
+                            (31, E_31)
                         } else { // 32 <= n < 34.
-                            if (value < E_33_U128) { // 32 <= n < 33.
-                                (32, E_32_U128)
+                            if (value < E_33) { // 32 <= n < 33.
+                                (32, E_32)
                             } else {
-                                (33, E_33_U128)
+                                (33, E_33)
                             }
                         }
                     }
                 } else { // 34 <= n < 39.
-                    if (value < E_36_U128) { // 34 <= n < 36.
-                        if (value < E_35_U128) { // 34 <= n < 35.
-                            (34, E_34_U128)
+                    if (value < E_36) { // 34 <= n < 36.
+                        if (value < E_35) { // 34 <= n < 35.
+                            (34, E_34)
                         } else {
-                            (35, E_35_U128)
+                            (35, E_35)
                         }
                     } else { // 36 <= n < 39.
-                        if (value < E_37_U128) { // 36 <= n < 37.
-                            (36, E_36_U128)
+                        if (value < E_37) { // 36 <= n < 37.
+                            (36, E_36)
                         } else { // 37 <= n < 39.
-                            if (value < E_38_U128) { // 37 <= n < 38.
-                                (37, E_37_U128)
+                            if (value < E_38) { // 37 <= n < 38.
+                                (37, E_37)
                             } else {
-                                (38, E_38_U128)
+                                (38, E_38)
                             }
                         }
                     }
@@ -281,139 +290,139 @@ module price::price {
     }
 
     #[test_only]
-    fun assert_floored_log_10(
+    fun assert_floored_log_10_with_power(
         value: u128, expected_log: u32, expected_power: u128
     ) {
-        let (log, power) = floored_log_10(value);
-        assert!(log == expected_log, 1);
-        assert!(power == expected_power, 2);
+        let (log, power) = floored_log_10_with_power(value);
+        assert!(log == expected_log);
+        assert!(power == expected_power);
     }
 
     #[test]
-    fun test_floored_log_10() {
+    fun test_floored_log_10_with_power() {
         // Test all powers of 10.
-        assert_floored_log_10(E_0_U128, 0, E_0_U128);
-        assert_floored_log_10(E_1_U128, 1, E_1_U128);
-        assert_floored_log_10(E_2_U128, 2, E_2_U128);
-        assert_floored_log_10(E_3_U128, 3, E_3_U128);
-        assert_floored_log_10(E_4_U128, 4, E_4_U128);
-        assert_floored_log_10(E_5_U128, 5, E_5_U128);
-        assert_floored_log_10(E_6_U128, 6, E_6_U128);
-        assert_floored_log_10(E_7_U128, 7, E_7_U128);
-        assert_floored_log_10(E_8_U128, 8, E_8_U128);
-        assert_floored_log_10(E_9_U128, 9, E_9_U128);
-        assert_floored_log_10(E_10_U128, 10, E_10_U128);
-        assert_floored_log_10(E_11_U128, 11, E_11_U128);
-        assert_floored_log_10(E_12_U128, 12, E_12_U128);
-        assert_floored_log_10(E_13_U128, 13, E_13_U128);
-        assert_floored_log_10(E_14_U128, 14, E_14_U128);
-        assert_floored_log_10(E_15_U128, 15, E_15_U128);
-        assert_floored_log_10(E_16_U128, 16, E_16_U128);
-        assert_floored_log_10(E_17_U128, 17, E_17_U128);
-        assert_floored_log_10(E_18_U128, 18, E_18_U128);
-        assert_floored_log_10(E_19_U128, 19, E_19_U128);
-        assert_floored_log_10(E_20_U128, 20, E_20_U128);
-        assert_floored_log_10(E_21_U128, 21, E_21_U128);
-        assert_floored_log_10(E_22_U128, 22, E_22_U128);
-        assert_floored_log_10(E_23_U128, 23, E_23_U128);
-        assert_floored_log_10(E_24_U128, 24, E_24_U128);
-        assert_floored_log_10(E_25_U128, 25, E_25_U128);
-        assert_floored_log_10(E_26_U128, 26, E_26_U128);
-        assert_floored_log_10(E_27_U128, 27, E_27_U128);
-        assert_floored_log_10(E_28_U128, 28, E_28_U128);
-        assert_floored_log_10(E_29_U128, 29, E_29_U128);
-        assert_floored_log_10(E_30_U128, 30, E_30_U128);
-        assert_floored_log_10(E_31_U128, 31, E_31_U128);
-        assert_floored_log_10(E_32_U128, 32, E_32_U128);
-        assert_floored_log_10(E_33_U128, 33, E_33_U128);
-        assert_floored_log_10(E_34_U128, 34, E_34_U128);
-        assert_floored_log_10(E_35_U128, 35, E_35_U128);
-        assert_floored_log_10(E_36_U128, 36, E_36_U128);
-        assert_floored_log_10(E_37_U128, 37, E_37_U128);
-        assert_floored_log_10(E_38_U128, 38, E_38_U128);
+        assert_floored_log_10_with_power(E_0, 0, E_0);
+        assert_floored_log_10_with_power(E_1, 1, E_1);
+        assert_floored_log_10_with_power(E_2, 2, E_2);
+        assert_floored_log_10_with_power(E_3, 3, E_3);
+        assert_floored_log_10_with_power(E_4, 4, E_4);
+        assert_floored_log_10_with_power(E_5, 5, E_5);
+        assert_floored_log_10_with_power(E_6, 6, E_6);
+        assert_floored_log_10_with_power(E_7, 7, E_7);
+        assert_floored_log_10_with_power(E_8, 8, E_8);
+        assert_floored_log_10_with_power(E_9, 9, E_9);
+        assert_floored_log_10_with_power(E_10, 10, E_10);
+        assert_floored_log_10_with_power(E_11, 11, E_11);
+        assert_floored_log_10_with_power(E_12, 12, E_12);
+        assert_floored_log_10_with_power(E_13, 13, E_13);
+        assert_floored_log_10_with_power(E_14, 14, E_14);
+        assert_floored_log_10_with_power(E_15, 15, E_15);
+        assert_floored_log_10_with_power(E_16, 16, E_16);
+        assert_floored_log_10_with_power(E_17, 17, E_17);
+        assert_floored_log_10_with_power(E_18, 18, E_18);
+        assert_floored_log_10_with_power(E_19, 19, E_19);
+        assert_floored_log_10_with_power(E_20, 20, E_20);
+        assert_floored_log_10_with_power(E_21, 21, E_21);
+        assert_floored_log_10_with_power(E_22, 22, E_22);
+        assert_floored_log_10_with_power(E_23, 23, E_23);
+        assert_floored_log_10_with_power(E_24, 24, E_24);
+        assert_floored_log_10_with_power(E_25, 25, E_25);
+        assert_floored_log_10_with_power(E_26, 26, E_26);
+        assert_floored_log_10_with_power(E_27, 27, E_27);
+        assert_floored_log_10_with_power(E_28, 28, E_28);
+        assert_floored_log_10_with_power(E_29, 29, E_29);
+        assert_floored_log_10_with_power(E_30, 30, E_30);
+        assert_floored_log_10_with_power(E_31, 31, E_31);
+        assert_floored_log_10_with_power(E_32, 32, E_32);
+        assert_floored_log_10_with_power(E_33, 33, E_33);
+        assert_floored_log_10_with_power(E_34, 34, E_34);
+        assert_floored_log_10_with_power(E_35, 35, E_35);
+        assert_floored_log_10_with_power(E_36, 36, E_36);
+        assert_floored_log_10_with_power(E_37, 37, E_37);
+        assert_floored_log_10_with_power(E_38, 38, E_38);
 
         // Test one more than each power of 10.
-        assert_floored_log_10(E_0_U128 + 1, 0, E_0_U128);
-        assert_floored_log_10(E_1_U128 + 1, 1, E_1_U128);
-        assert_floored_log_10(E_2_U128 + 1, 2, E_2_U128);
-        assert_floored_log_10(E_3_U128 + 1, 3, E_3_U128);
-        assert_floored_log_10(E_4_U128 + 1, 4, E_4_U128);
-        assert_floored_log_10(E_5_U128 + 1, 5, E_5_U128);
-        assert_floored_log_10(E_6_U128 + 1, 6, E_6_U128);
-        assert_floored_log_10(E_7_U128 + 1, 7, E_7_U128);
-        assert_floored_log_10(E_8_U128 + 1, 8, E_8_U128);
-        assert_floored_log_10(E_9_U128 + 1, 9, E_9_U128);
-        assert_floored_log_10(E_10_U128 + 1, 10, E_10_U128);
-        assert_floored_log_10(E_11_U128 + 1, 11, E_11_U128);
-        assert_floored_log_10(E_12_U128 + 1, 12, E_12_U128);
-        assert_floored_log_10(E_13_U128 + 1, 13, E_13_U128);
-        assert_floored_log_10(E_14_U128 + 1, 14, E_14_U128);
-        assert_floored_log_10(E_15_U128 + 1, 15, E_15_U128);
-        assert_floored_log_10(E_16_U128 + 1, 16, E_16_U128);
-        assert_floored_log_10(E_17_U128 + 1, 17, E_17_U128);
-        assert_floored_log_10(E_18_U128 + 1, 18, E_18_U128);
-        assert_floored_log_10(E_19_U128 + 1, 19, E_19_U128);
-        assert_floored_log_10(E_20_U128 + 1, 20, E_20_U128);
-        assert_floored_log_10(E_21_U128 + 1, 21, E_21_U128);
-        assert_floored_log_10(E_22_U128 + 1, 22, E_22_U128);
-        assert_floored_log_10(E_23_U128 + 1, 23, E_23_U128);
-        assert_floored_log_10(E_24_U128 + 1, 24, E_24_U128);
-        assert_floored_log_10(E_25_U128 + 1, 25, E_25_U128);
-        assert_floored_log_10(E_26_U128 + 1, 26, E_26_U128);
-        assert_floored_log_10(E_27_U128 + 1, 27, E_27_U128);
-        assert_floored_log_10(E_28_U128 + 1, 28, E_28_U128);
-        assert_floored_log_10(E_29_U128 + 1, 29, E_29_U128);
-        assert_floored_log_10(E_30_U128 + 1, 30, E_30_U128);
-        assert_floored_log_10(E_31_U128 + 1, 31, E_31_U128);
-        assert_floored_log_10(E_32_U128 + 1, 32, E_32_U128);
-        assert_floored_log_10(E_33_U128 + 1, 33, E_33_U128);
-        assert_floored_log_10(E_34_U128 + 1, 34, E_34_U128);
-        assert_floored_log_10(E_35_U128 + 1, 35, E_35_U128);
-        assert_floored_log_10(E_36_U128 + 1, 36, E_36_U128);
-        assert_floored_log_10(E_37_U128 + 1, 37, E_37_U128);
-        assert_floored_log_10(E_38_U128 + 1, 38, E_38_U128);
+        assert_floored_log_10_with_power(E_0 + 1, 0, E_0);
+        assert_floored_log_10_with_power(E_1 + 1, 1, E_1);
+        assert_floored_log_10_with_power(E_2 + 1, 2, E_2);
+        assert_floored_log_10_with_power(E_3 + 1, 3, E_3);
+        assert_floored_log_10_with_power(E_4 + 1, 4, E_4);
+        assert_floored_log_10_with_power(E_5 + 1, 5, E_5);
+        assert_floored_log_10_with_power(E_6 + 1, 6, E_6);
+        assert_floored_log_10_with_power(E_7 + 1, 7, E_7);
+        assert_floored_log_10_with_power(E_8 + 1, 8, E_8);
+        assert_floored_log_10_with_power(E_9 + 1, 9, E_9);
+        assert_floored_log_10_with_power(E_10 + 1, 10, E_10);
+        assert_floored_log_10_with_power(E_11 + 1, 11, E_11);
+        assert_floored_log_10_with_power(E_12 + 1, 12, E_12);
+        assert_floored_log_10_with_power(E_13 + 1, 13, E_13);
+        assert_floored_log_10_with_power(E_14 + 1, 14, E_14);
+        assert_floored_log_10_with_power(E_15 + 1, 15, E_15);
+        assert_floored_log_10_with_power(E_16 + 1, 16, E_16);
+        assert_floored_log_10_with_power(E_17 + 1, 17, E_17);
+        assert_floored_log_10_with_power(E_18 + 1, 18, E_18);
+        assert_floored_log_10_with_power(E_19 + 1, 19, E_19);
+        assert_floored_log_10_with_power(E_20 + 1, 20, E_20);
+        assert_floored_log_10_with_power(E_21 + 1, 21, E_21);
+        assert_floored_log_10_with_power(E_22 + 1, 22, E_22);
+        assert_floored_log_10_with_power(E_23 + 1, 23, E_23);
+        assert_floored_log_10_with_power(E_24 + 1, 24, E_24);
+        assert_floored_log_10_with_power(E_25 + 1, 25, E_25);
+        assert_floored_log_10_with_power(E_26 + 1, 26, E_26);
+        assert_floored_log_10_with_power(E_27 + 1, 27, E_27);
+        assert_floored_log_10_with_power(E_28 + 1, 28, E_28);
+        assert_floored_log_10_with_power(E_29 + 1, 29, E_29);
+        assert_floored_log_10_with_power(E_30 + 1, 30, E_30);
+        assert_floored_log_10_with_power(E_31 + 1, 31, E_31);
+        assert_floored_log_10_with_power(E_32 + 1, 32, E_32);
+        assert_floored_log_10_with_power(E_33 + 1, 33, E_33);
+        assert_floored_log_10_with_power(E_34 + 1, 34, E_34);
+        assert_floored_log_10_with_power(E_35 + 1, 35, E_35);
+        assert_floored_log_10_with_power(E_36 + 1, 36, E_36);
+        assert_floored_log_10_with_power(E_37 + 1, 37, E_37);
+        assert_floored_log_10_with_power(E_38 + 1, 38, E_38);
 
         // Test one less than each power of 10.
-        assert_floored_log_10(E_1_U128 - 1, 0, E_0_U128);
-        assert_floored_log_10(E_2_U128 - 1, 1, E_1_U128);
-        assert_floored_log_10(E_3_U128 - 1, 2, E_2_U128);
-        assert_floored_log_10(E_4_U128 - 1, 3, E_3_U128);
-        assert_floored_log_10(E_5_U128 - 1, 4, E_4_U128);
-        assert_floored_log_10(E_6_U128 - 1, 5, E_5_U128);
-        assert_floored_log_10(E_7_U128 - 1, 6, E_6_U128);
-        assert_floored_log_10(E_8_U128 - 1, 7, E_7_U128);
-        assert_floored_log_10(E_9_U128 - 1, 8, E_8_U128);
-        assert_floored_log_10(E_10_U128 - 1, 9, E_9_U128);
-        assert_floored_log_10(E_11_U128 - 1, 10, E_10_U128);
-        assert_floored_log_10(E_12_U128 - 1, 11, E_11_U128);
-        assert_floored_log_10(E_13_U128 - 1, 12, E_12_U128);
-        assert_floored_log_10(E_14_U128 - 1, 13, E_13_U128);
-        assert_floored_log_10(E_15_U128 - 1, 14, E_14_U128);
-        assert_floored_log_10(E_16_U128 - 1, 15, E_15_U128);
-        assert_floored_log_10(E_17_U128 - 1, 16, E_16_U128);
-        assert_floored_log_10(E_18_U128 - 1, 17, E_17_U128);
-        assert_floored_log_10(E_19_U128 - 1, 18, E_18_U128);
-        assert_floored_log_10(E_20_U128 - 1, 19, E_19_U128);
-        assert_floored_log_10(E_21_U128 - 1, 20, E_20_U128);
-        assert_floored_log_10(E_22_U128 - 1, 21, E_21_U128);
-        assert_floored_log_10(E_23_U128 - 1, 22, E_22_U128);
-        assert_floored_log_10(E_24_U128 - 1, 23, E_23_U128);
-        assert_floored_log_10(E_25_U128 - 1, 24, E_24_U128);
-        assert_floored_log_10(E_26_U128 - 1, 25, E_25_U128);
-        assert_floored_log_10(E_27_U128 - 1, 26, E_26_U128);
-        assert_floored_log_10(E_28_U128 - 1, 27, E_27_U128);
-        assert_floored_log_10(E_29_U128 - 1, 28, E_28_U128);
-        assert_floored_log_10(E_30_U128 - 1, 29, E_29_U128);
-        assert_floored_log_10(E_31_U128 - 1, 30, E_30_U128);
-        assert_floored_log_10(E_32_U128 - 1, 31, E_31_U128);
-        assert_floored_log_10(E_33_U128 - 1, 32, E_32_U128);
-        assert_floored_log_10(E_34_U128 - 1, 33, E_33_U128);
-        assert_floored_log_10(E_35_U128 - 1, 34, E_34_U128);
-        assert_floored_log_10(E_36_U128 - 1, 35, E_35_U128);
-        assert_floored_log_10(E_37_U128 - 1, 36, E_36_U128);
-        assert_floored_log_10(E_38_U128 - 1, 37, E_37_U128);
+        assert_floored_log_10_with_power(E_1 - 1, 0, E_0);
+        assert_floored_log_10_with_power(E_2 - 1, 1, E_1);
+        assert_floored_log_10_with_power(E_3 - 1, 2, E_2);
+        assert_floored_log_10_with_power(E_4 - 1, 3, E_3);
+        assert_floored_log_10_with_power(E_5 - 1, 4, E_4);
+        assert_floored_log_10_with_power(E_6 - 1, 5, E_5);
+        assert_floored_log_10_with_power(E_7 - 1, 6, E_6);
+        assert_floored_log_10_with_power(E_8 - 1, 7, E_7);
+        assert_floored_log_10_with_power(E_9 - 1, 8, E_8);
+        assert_floored_log_10_with_power(E_10 - 1, 9, E_9);
+        assert_floored_log_10_with_power(E_11 - 1, 10, E_10);
+        assert_floored_log_10_with_power(E_12 - 1, 11, E_11);
+        assert_floored_log_10_with_power(E_13 - 1, 12, E_12);
+        assert_floored_log_10_with_power(E_14 - 1, 13, E_13);
+        assert_floored_log_10_with_power(E_15 - 1, 14, E_14);
+        assert_floored_log_10_with_power(E_16 - 1, 15, E_15);
+        assert_floored_log_10_with_power(E_17 - 1, 16, E_16);
+        assert_floored_log_10_with_power(E_18 - 1, 17, E_17);
+        assert_floored_log_10_with_power(E_19 - 1, 18, E_18);
+        assert_floored_log_10_with_power(E_20 - 1, 19, E_19);
+        assert_floored_log_10_with_power(E_21 - 1, 20, E_20);
+        assert_floored_log_10_with_power(E_22 - 1, 21, E_21);
+        assert_floored_log_10_with_power(E_23 - 1, 22, E_22);
+        assert_floored_log_10_with_power(E_24 - 1, 23, E_23);
+        assert_floored_log_10_with_power(E_25 - 1, 24, E_24);
+        assert_floored_log_10_with_power(E_26 - 1, 25, E_25);
+        assert_floored_log_10_with_power(E_27 - 1, 26, E_26);
+        assert_floored_log_10_with_power(E_28 - 1, 27, E_27);
+        assert_floored_log_10_with_power(E_29 - 1, 28, E_28);
+        assert_floored_log_10_with_power(E_30 - 1, 29, E_29);
+        assert_floored_log_10_with_power(E_31 - 1, 30, E_30);
+        assert_floored_log_10_with_power(E_32 - 1, 31, E_31);
+        assert_floored_log_10_with_power(E_33 - 1, 32, E_32);
+        assert_floored_log_10_with_power(E_34 - 1, 33, E_33);
+        assert_floored_log_10_with_power(E_35 - 1, 34, E_34);
+        assert_floored_log_10_with_power(E_36 - 1, 35, E_35);
+        assert_floored_log_10_with_power(E_37 - 1, 36, E_36);
+        assert_floored_log_10_with_power(E_38 - 1, 37, E_37);
 
         // Test max value that can fit in a u128.
-        assert_floored_log_10(U128_MAX, 38, E_38_U128);
+        assert_floored_log_10_with_power(MAX_U128, 38, E_38);
     }
 }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -179,32 +179,32 @@ module price::price {
                 if (value < E_4) { // 0 <= n < 4.
                     if (value < E_2) { // 0 <= n < 2.
                         if (value < E_1) { // 0 <= n < 1.
-                            (0, E_0)
+                            (N_0, E_0)
                         } else {
-                            (1, E_1)
+                            (N_1, E_1)
                         }
                     } else { // 2 <= n < 4.
                         if (value < E_3) { // 2 <= n < 3.
-                            (2, E_2)
+                            (N_2, E_2)
                         } else {
-                            (3, E_3)
+                            (N_3, E_3)
                         }
                     }
                 } else { // 4 <= n < 9.
                     if (value < E_6) { // 4 <= n < 6.
                         if (value < E_5) { // 4 <= n < 5.
-                            (4, E_4)
+                            (N_4, E_4)
                         } else {
-                            (5, E_5)
+                            (N_5, E_5)
                         }
                     } else { // 6 <= n < 9.
                         if (value < E_7) { // 6 <= n < 7.
-                            (6, E_6)
+                            (N_6, E_6)
                         } else { // 7 <= n < 9.
                             if (value < E_8) { // 7 <= n < 8.
-                                (7, E_7)
+                                (N_7, E_7)
                             } else {
-                                (8, E_8)
+                                (N_8, E_8)
                             }
                         }
                     }
@@ -213,36 +213,36 @@ module price::price {
                 if (value < E_14) { // 9 <= n < 14.
                     if (value < E_11) { // 9 <= n < 11.
                         if (value < E_10) { // 9 <= n < 10.
-                            (9, E_9)
+                            (N_9, E_9)
                         } else {
-                            (10, E_10)
+                            (N_10, E_10)
                         }
                     } else { // 11 <= n < 14.
                         if (value < E_12) { // 11 <= n < 12.
-                            (11, E_11)
+                            (N_11, E_11)
                         } else {
                             if (value < E_13) { // 12 <= n < 13.
-                                (12, E_12)
+                                (N_12, E_12)
                             } else {
-                                (13, E_13)
+                                (N_13, E_13)
                             }
                         }
                     }
                 } else { // 14 <= n < 19.
                     if (value < E_16) { // 14 <= n < 16.
                         if (value < E_15) { // 14 <= n < 15.
-                            (14, E_14)
+                            (N_14, E_14)
                         } else {
-                            (15, E_15)
+                            (N_15, E_15)
                         }
                     } else { // 16 <= n < 19.
                         if (value < E_17) { // 16 <= n < 17.
-                            (16, E_16)
+                            (N_16, E_16)
                         } else { // 17 <= n < 19.
                             if (value < E_18) { // 17 <= n < 18.
-                                (17, E_17)
+                                (N_17, E_17)
                             } else {
-                                (18, E_18)
+                                (N_18, E_18)
                             }
                         }
                     }
@@ -253,36 +253,36 @@ module price::price {
                 if (value < E_24) { // 19 <= n < 24.
                     if (value < E_21) { // 19 <= n < 21.
                         if (value < E_20) { // 19 <= n < 20.
-                            (19, E_19)
+                            (N_19, E_19)
                         } else {
-                            (20, E_20)
+                            (N_20, E_20)
                         }
                     } else { // 21 <= n < 24.
                         if (value < E_22) { // 21 <= n < 22.
-                            (21, E_21)
+                            (N_21, E_21)
                         } else { // 22 <= n < 24.
                             if (value < E_23) { // 22 <= n < 23.
-                                (22, E_22)
+                                (N_22, E_22)
                             } else {
-                                (23, E_23)
+                                (N_23, E_23)
                             }
                         }
                     }
                 } else { // 24 <= n < 29.
                     if (value < E_26) { // 24 <= n < 26.
                         if (value < E_25) { // 24 <= n < 25.
-                            (24, E_24)
+                            (N_24, E_24)
                         } else {
-                            (25, E_25)
+                            (N_25, E_25)
                         }
                     } else { // 26 <= n < 29.
                         if (value < E_27) { // 26 <= n < 27.
-                            (26, E_26)
+                            (N_26, E_26)
                         } else { // 27 <= n < 29.
                             if (value < E_28) { // 27 <= n < 28.
-                                (27, E_27)
+                                (N_27, E_27)
                             } else {
-                                (28, E_28)
+                                (N_28, E_28)
                             }
                         }
                     }
@@ -291,36 +291,36 @@ module price::price {
                 if (value < E_34) { // 29 <= n < 34.
                     if (value < E_31) { // 29 <= n < 31.
                         if (value < E_30) { // 29 <= n < 30.
-                            (29, E_29)
+                            (N_29, E_29)
                         } else {
-                            (30, E_30)
+                            (N_30, E_30)
                         }
                     } else { // 31 <= n < 34.
                         if (value < E_32) { // 31 <= n < 32.
-                            (31, E_31)
+                            (N_31, E_31)
                         } else { // 32 <= n < 34.
                             if (value < E_33) { // 32 <= n < 33.
-                                (32, E_32)
+                                (N_32, E_32)
                             } else {
-                                (33, E_33)
+                                (N_33, E_33)
                             }
                         }
                     }
                 } else { // 34 <= n < 39.
                     if (value < E_36) { // 34 <= n < 36.
                         if (value < E_35) { // 34 <= n < 35.
-                            (34, E_34)
+                            (N_34, E_34)
                         } else {
-                            (35, E_35)
+                            (N_35, E_35)
                         }
                     } else { // 36 <= n < 39.
                         if (value < E_37) { // 36 <= n < 37.
-                            (36, E_36)
+                            (N_36, E_36)
                         } else { // 37 <= n < 39.
                             if (value < E_38) { // 37 <= n < 38.
-                                (37, E_37)
+                                (N_37, E_37)
                             } else {
-                                (38, E_38)
+                                (N_38, E_38)
                             }
                         }
                     }
@@ -341,128 +341,128 @@ module price::price {
     #[test]
     fun test_floored_log_10_with_power() {
         // Test all powers of 10.
-        assert_floored_log_10_with_power(E_0, 0, E_0);
-        assert_floored_log_10_with_power(E_1, 1, E_1);
-        assert_floored_log_10_with_power(E_2, 2, E_2);
-        assert_floored_log_10_with_power(E_3, 3, E_3);
-        assert_floored_log_10_with_power(E_4, 4, E_4);
-        assert_floored_log_10_with_power(E_5, 5, E_5);
-        assert_floored_log_10_with_power(E_6, 6, E_6);
-        assert_floored_log_10_with_power(E_7, 7, E_7);
-        assert_floored_log_10_with_power(E_8, 8, E_8);
-        assert_floored_log_10_with_power(E_9, 9, E_9);
-        assert_floored_log_10_with_power(E_10, 10, E_10);
-        assert_floored_log_10_with_power(E_11, 11, E_11);
-        assert_floored_log_10_with_power(E_12, 12, E_12);
-        assert_floored_log_10_with_power(E_13, 13, E_13);
-        assert_floored_log_10_with_power(E_14, 14, E_14);
-        assert_floored_log_10_with_power(E_15, 15, E_15);
-        assert_floored_log_10_with_power(E_16, 16, E_16);
-        assert_floored_log_10_with_power(E_17, 17, E_17);
-        assert_floored_log_10_with_power(E_18, 18, E_18);
-        assert_floored_log_10_with_power(E_19, 19, E_19);
-        assert_floored_log_10_with_power(E_20, 20, E_20);
-        assert_floored_log_10_with_power(E_21, 21, E_21);
-        assert_floored_log_10_with_power(E_22, 22, E_22);
-        assert_floored_log_10_with_power(E_23, 23, E_23);
-        assert_floored_log_10_with_power(E_24, 24, E_24);
-        assert_floored_log_10_with_power(E_25, 25, E_25);
-        assert_floored_log_10_with_power(E_26, 26, E_26);
-        assert_floored_log_10_with_power(E_27, 27, E_27);
-        assert_floored_log_10_with_power(E_28, 28, E_28);
-        assert_floored_log_10_with_power(E_29, 29, E_29);
-        assert_floored_log_10_with_power(E_30, 30, E_30);
-        assert_floored_log_10_with_power(E_31, 31, E_31);
-        assert_floored_log_10_with_power(E_32, 32, E_32);
-        assert_floored_log_10_with_power(E_33, 33, E_33);
-        assert_floored_log_10_with_power(E_34, 34, E_34);
-        assert_floored_log_10_with_power(E_35, 35, E_35);
-        assert_floored_log_10_with_power(E_36, 36, E_36);
-        assert_floored_log_10_with_power(E_37, 37, E_37);
-        assert_floored_log_10_with_power(E_38, 38, E_38);
+        assert_floored_log_10_with_power(E_0, N_0, E_0);
+        assert_floored_log_10_with_power(E_1, N_1, E_1);
+        assert_floored_log_10_with_power(E_2, N_2, E_2);
+        assert_floored_log_10_with_power(E_3, N_3, E_3);
+        assert_floored_log_10_with_power(E_4, N_4, E_4);
+        assert_floored_log_10_with_power(E_5, N_5, E_5);
+        assert_floored_log_10_with_power(E_6, N_6, E_6);
+        assert_floored_log_10_with_power(E_7, N_7, E_7);
+        assert_floored_log_10_with_power(E_8, N_8, E_8);
+        assert_floored_log_10_with_power(E_9, N_9, E_9);
+        assert_floored_log_10_with_power(E_10, N_10, E_10);
+        assert_floored_log_10_with_power(E_11, N_11, E_11);
+        assert_floored_log_10_with_power(E_12, N_12, E_12);
+        assert_floored_log_10_with_power(E_13, N_13, E_13);
+        assert_floored_log_10_with_power(E_14, N_14, E_14);
+        assert_floored_log_10_with_power(E_15, N_15, E_15);
+        assert_floored_log_10_with_power(E_16, N_16, E_16);
+        assert_floored_log_10_with_power(E_17, N_17, E_17);
+        assert_floored_log_10_with_power(E_18, N_18, E_18);
+        assert_floored_log_10_with_power(E_19, N_19, E_19);
+        assert_floored_log_10_with_power(E_20, N_20, E_20);
+        assert_floored_log_10_with_power(E_21, N_21, E_21);
+        assert_floored_log_10_with_power(E_22, N_22, E_22);
+        assert_floored_log_10_with_power(E_23, N_23, E_23);
+        assert_floored_log_10_with_power(E_24, N_24, E_24);
+        assert_floored_log_10_with_power(E_25, N_25, E_25);
+        assert_floored_log_10_with_power(E_26, N_26, E_26);
+        assert_floored_log_10_with_power(E_27, N_27, E_27);
+        assert_floored_log_10_with_power(E_28, N_28, E_28);
+        assert_floored_log_10_with_power(E_29, N_29, E_29);
+        assert_floored_log_10_with_power(E_30, N_30, E_30);
+        assert_floored_log_10_with_power(E_31, N_31, E_31);
+        assert_floored_log_10_with_power(E_32, N_32, E_32);
+        assert_floored_log_10_with_power(E_33, N_33, E_33);
+        assert_floored_log_10_with_power(E_34, N_34, E_34);
+        assert_floored_log_10_with_power(E_35, N_35, E_35);
+        assert_floored_log_10_with_power(E_36, N_36, E_36);
+        assert_floored_log_10_with_power(E_37, N_37, E_37);
+        assert_floored_log_10_with_power(E_38, N_38, E_38);
 
         // Test one more than each power of 10.
-        assert_floored_log_10_with_power(E_0 + 1, 0, E_0);
-        assert_floored_log_10_with_power(E_1 + 1, 1, E_1);
-        assert_floored_log_10_with_power(E_2 + 1, 2, E_2);
-        assert_floored_log_10_with_power(E_3 + 1, 3, E_3);
-        assert_floored_log_10_with_power(E_4 + 1, 4, E_4);
-        assert_floored_log_10_with_power(E_5 + 1, 5, E_5);
-        assert_floored_log_10_with_power(E_6 + 1, 6, E_6);
-        assert_floored_log_10_with_power(E_7 + 1, 7, E_7);
-        assert_floored_log_10_with_power(E_8 + 1, 8, E_8);
-        assert_floored_log_10_with_power(E_9 + 1, 9, E_9);
-        assert_floored_log_10_with_power(E_10 + 1, 10, E_10);
-        assert_floored_log_10_with_power(E_11 + 1, 11, E_11);
-        assert_floored_log_10_with_power(E_12 + 1, 12, E_12);
-        assert_floored_log_10_with_power(E_13 + 1, 13, E_13);
-        assert_floored_log_10_with_power(E_14 + 1, 14, E_14);
-        assert_floored_log_10_with_power(E_15 + 1, 15, E_15);
-        assert_floored_log_10_with_power(E_16 + 1, 16, E_16);
-        assert_floored_log_10_with_power(E_17 + 1, 17, E_17);
-        assert_floored_log_10_with_power(E_18 + 1, 18, E_18);
-        assert_floored_log_10_with_power(E_19 + 1, 19, E_19);
-        assert_floored_log_10_with_power(E_20 + 1, 20, E_20);
-        assert_floored_log_10_with_power(E_21 + 1, 21, E_21);
-        assert_floored_log_10_with_power(E_22 + 1, 22, E_22);
-        assert_floored_log_10_with_power(E_23 + 1, 23, E_23);
-        assert_floored_log_10_with_power(E_24 + 1, 24, E_24);
-        assert_floored_log_10_with_power(E_25 + 1, 25, E_25);
-        assert_floored_log_10_with_power(E_26 + 1, 26, E_26);
-        assert_floored_log_10_with_power(E_27 + 1, 27, E_27);
-        assert_floored_log_10_with_power(E_28 + 1, 28, E_28);
-        assert_floored_log_10_with_power(E_29 + 1, 29, E_29);
-        assert_floored_log_10_with_power(E_30 + 1, 30, E_30);
-        assert_floored_log_10_with_power(E_31 + 1, 31, E_31);
-        assert_floored_log_10_with_power(E_32 + 1, 32, E_32);
-        assert_floored_log_10_with_power(E_33 + 1, 33, E_33);
-        assert_floored_log_10_with_power(E_34 + 1, 34, E_34);
-        assert_floored_log_10_with_power(E_35 + 1, 35, E_35);
-        assert_floored_log_10_with_power(E_36 + 1, 36, E_36);
-        assert_floored_log_10_with_power(E_37 + 1, 37, E_37);
-        assert_floored_log_10_with_power(E_38 + 1, 38, E_38);
+        assert_floored_log_10_with_power(E_0 + 1, N_0, E_0);
+        assert_floored_log_10_with_power(E_1 + 1, N_1, E_1);
+        assert_floored_log_10_with_power(E_2 + 1, N_2, E_2);
+        assert_floored_log_10_with_power(E_3 + 1, N_3, E_3);
+        assert_floored_log_10_with_power(E_4 + 1, N_4, E_4);
+        assert_floored_log_10_with_power(E_5 + 1, N_5, E_5);
+        assert_floored_log_10_with_power(E_6 + 1, N_6, E_6);
+        assert_floored_log_10_with_power(E_7 + 1, N_7, E_7);
+        assert_floored_log_10_with_power(E_8 + 1, N_8, E_8);
+        assert_floored_log_10_with_power(E_9 + 1, N_9, E_9);
+        assert_floored_log_10_with_power(E_10 + 1, N_10, E_10);
+        assert_floored_log_10_with_power(E_11 + 1, N_11, E_11);
+        assert_floored_log_10_with_power(E_12 + 1, N_12, E_12);
+        assert_floored_log_10_with_power(E_13 + 1, N_13, E_13);
+        assert_floored_log_10_with_power(E_14 + 1, N_14, E_14);
+        assert_floored_log_10_with_power(E_15 + 1, N_15, E_15);
+        assert_floored_log_10_with_power(E_16 + 1, N_16, E_16);
+        assert_floored_log_10_with_power(E_17 + 1, N_17, E_17);
+        assert_floored_log_10_with_power(E_18 + 1, N_18, E_18);
+        assert_floored_log_10_with_power(E_19 + 1, N_19, E_19);
+        assert_floored_log_10_with_power(E_20 + 1, N_20, E_20);
+        assert_floored_log_10_with_power(E_21 + 1, N_21, E_21);
+        assert_floored_log_10_with_power(E_22 + 1, N_22, E_22);
+        assert_floored_log_10_with_power(E_23 + 1, N_23, E_23);
+        assert_floored_log_10_with_power(E_24 + 1, N_24, E_24);
+        assert_floored_log_10_with_power(E_25 + 1, N_25, E_25);
+        assert_floored_log_10_with_power(E_26 + 1, N_26, E_26);
+        assert_floored_log_10_with_power(E_27 + 1, N_27, E_27);
+        assert_floored_log_10_with_power(E_28 + 1, N_28, E_28);
+        assert_floored_log_10_with_power(E_29 + 1, N_29, E_29);
+        assert_floored_log_10_with_power(E_30 + 1, N_30, E_30);
+        assert_floored_log_10_with_power(E_31 + 1, N_31, E_31);
+        assert_floored_log_10_with_power(E_32 + 1, N_32, E_32);
+        assert_floored_log_10_with_power(E_33 + 1, N_33, E_33);
+        assert_floored_log_10_with_power(E_34 + 1, N_34, E_34);
+        assert_floored_log_10_with_power(E_35 + 1, N_35, E_35);
+        assert_floored_log_10_with_power(E_36 + 1, N_36, E_36);
+        assert_floored_log_10_with_power(E_37 + 1, N_37, E_37);
+        assert_floored_log_10_with_power(E_38 + 1, N_38, E_38);
 
         // Test one less than each power of 10.
-        assert_floored_log_10_with_power(E_1 - 1, 0, E_0);
-        assert_floored_log_10_with_power(E_2 - 1, 1, E_1);
-        assert_floored_log_10_with_power(E_3 - 1, 2, E_2);
-        assert_floored_log_10_with_power(E_4 - 1, 3, E_3);
-        assert_floored_log_10_with_power(E_5 - 1, 4, E_4);
-        assert_floored_log_10_with_power(E_6 - 1, 5, E_5);
-        assert_floored_log_10_with_power(E_7 - 1, 6, E_6);
-        assert_floored_log_10_with_power(E_8 - 1, 7, E_7);
-        assert_floored_log_10_with_power(E_9 - 1, 8, E_8);
-        assert_floored_log_10_with_power(E_10 - 1, 9, E_9);
-        assert_floored_log_10_with_power(E_11 - 1, 10, E_10);
-        assert_floored_log_10_with_power(E_12 - 1, 11, E_11);
-        assert_floored_log_10_with_power(E_13 - 1, 12, E_12);
-        assert_floored_log_10_with_power(E_14 - 1, 13, E_13);
-        assert_floored_log_10_with_power(E_15 - 1, 14, E_14);
-        assert_floored_log_10_with_power(E_16 - 1, 15, E_15);
-        assert_floored_log_10_with_power(E_17 - 1, 16, E_16);
-        assert_floored_log_10_with_power(E_18 - 1, 17, E_17);
-        assert_floored_log_10_with_power(E_19 - 1, 18, E_18);
-        assert_floored_log_10_with_power(E_20 - 1, 19, E_19);
-        assert_floored_log_10_with_power(E_21 - 1, 20, E_20);
-        assert_floored_log_10_with_power(E_22 - 1, 21, E_21);
-        assert_floored_log_10_with_power(E_23 - 1, 22, E_22);
-        assert_floored_log_10_with_power(E_24 - 1, 23, E_23);
-        assert_floored_log_10_with_power(E_25 - 1, 24, E_24);
-        assert_floored_log_10_with_power(E_26 - 1, 25, E_25);
-        assert_floored_log_10_with_power(E_27 - 1, 26, E_26);
-        assert_floored_log_10_with_power(E_28 - 1, 27, E_27);
-        assert_floored_log_10_with_power(E_29 - 1, 28, E_28);
-        assert_floored_log_10_with_power(E_30 - 1, 29, E_29);
-        assert_floored_log_10_with_power(E_31 - 1, 30, E_30);
-        assert_floored_log_10_with_power(E_32 - 1, 31, E_31);
-        assert_floored_log_10_with_power(E_33 - 1, 32, E_32);
-        assert_floored_log_10_with_power(E_34 - 1, 33, E_33);
-        assert_floored_log_10_with_power(E_35 - 1, 34, E_34);
-        assert_floored_log_10_with_power(E_36 - 1, 35, E_35);
-        assert_floored_log_10_with_power(E_37 - 1, 36, E_36);
-        assert_floored_log_10_with_power(E_38 - 1, 37, E_37);
+        assert_floored_log_10_with_power(E_1 - 1, N_0, E_0);
+        assert_floored_log_10_with_power(E_2 - 1, N_1, E_1);
+        assert_floored_log_10_with_power(E_3 - 1, N_2, E_2);
+        assert_floored_log_10_with_power(E_4 - 1, N_3, E_3);
+        assert_floored_log_10_with_power(E_5 - 1, N_4, E_4);
+        assert_floored_log_10_with_power(E_6 - 1, N_5, E_5);
+        assert_floored_log_10_with_power(E_7 - 1, N_6, E_6);
+        assert_floored_log_10_with_power(E_8 - 1, N_7, E_7);
+        assert_floored_log_10_with_power(E_9 - 1, N_8, E_8);
+        assert_floored_log_10_with_power(E_10 - 1, N_9, E_9);
+        assert_floored_log_10_with_power(E_11 - 1, N_10, E_10);
+        assert_floored_log_10_with_power(E_12 - 1, N_11, E_11);
+        assert_floored_log_10_with_power(E_13 - 1, N_12, E_12);
+        assert_floored_log_10_with_power(E_14 - 1, N_13, E_13);
+        assert_floored_log_10_with_power(E_15 - 1, N_14, E_14);
+        assert_floored_log_10_with_power(E_16 - 1, N_15, E_15);
+        assert_floored_log_10_with_power(E_17 - 1, N_16, E_16);
+        assert_floored_log_10_with_power(E_18 - 1, N_17, E_17);
+        assert_floored_log_10_with_power(E_19 - 1, N_18, E_18);
+        assert_floored_log_10_with_power(E_20 - 1, N_19, E_19);
+        assert_floored_log_10_with_power(E_21 - 1, N_20, E_20);
+        assert_floored_log_10_with_power(E_22 - 1, N_21, E_21);
+        assert_floored_log_10_with_power(E_23 - 1, N_22, E_22);
+        assert_floored_log_10_with_power(E_24 - 1, N_23, E_23);
+        assert_floored_log_10_with_power(E_25 - 1, N_24, E_24);
+        assert_floored_log_10_with_power(E_26 - 1, N_25, E_25);
+        assert_floored_log_10_with_power(E_27 - 1, N_26, E_26);
+        assert_floored_log_10_with_power(E_28 - 1, N_27, E_27);
+        assert_floored_log_10_with_power(E_29 - 1, N_28, E_28);
+        assert_floored_log_10_with_power(E_30 - 1, N_29, E_29);
+        assert_floored_log_10_with_power(E_31 - 1, N_30, E_30);
+        assert_floored_log_10_with_power(E_32 - 1, N_31, E_31);
+        assert_floored_log_10_with_power(E_33 - 1, N_32, E_32);
+        assert_floored_log_10_with_power(E_34 - 1, N_33, E_33);
+        assert_floored_log_10_with_power(E_35 - 1, N_34, E_34);
+        assert_floored_log_10_with_power(E_36 - 1, N_35, E_35);
+        assert_floored_log_10_with_power(E_37 - 1, N_36, E_36);
+        assert_floored_log_10_with_power(E_38 - 1, N_37, E_37);
 
-        // Test max value that can fit in a u128.
-        assert_floored_log_10_with_power(MAX_U128, 38, E_38);
+        // Test max value that can fit in a `u128`.
+        assert_floored_log_10_with_power(MAX_U128, N_38, E_38);
     }
 }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -9,6 +9,8 @@ module price::price {
     /// The exponent of the largest power of 10 that can fit in a `u128`.
     /// In Python: `math.floor(math.log10(2 ** 128 - 1))`
     const EXP_MAX_U128: u32 = 38;
+    /// The largest `u128` value. In Python: `f"{2 ** 128 - 1:_}"`
+    const U128_MAX: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
 
     const E_0_U128: u128 = 1;
     const E_1_U128: u128 = 10;
@@ -52,6 +54,8 @@ module price::price {
 
     /// Base term is 0.
     const E_BASE_ZERO: u64 = 1;
+    /// Logarithm of 0 is undefined.
+    const E_LOG_0_UNDEFINED: u64 = 2;
 
     /*
     #[view]
@@ -71,6 +75,7 @@ module price::price {
     /// Return the floored base-10 logarithm of `value`. Uses binary search for speed, with each new
     /// branch of the tree testing at the floored midpoint of the previous branch.
     public fun floored_log_10(value: u128): u32 {
+        assert!(value > 0, E_LOG_0_UNDEFINED);
         if (value < E_19_U128) { // 0 <= n < 19.
             if (value < E_9_U128) { // 0 <= n < 9.
                 if (value < E_4_U128) { // 0 <= n < 4.
@@ -176,7 +181,19 @@ module price::price {
                         }
                     }
                 } else { // 34 <= n < 39.
-                    16
+                    if (value < E_36_U128) { // 34 <= n < 36.
+                        if (value < E_35_U128) { // 34 <= n < 35.
+                            34
+                        } else { 35 }
+                    } else { // 36 <= n < 39.
+                        if (value < E_37_U128) { // 36 <= n < 37.
+                            36
+                        } else { // 37 <= n < 39.
+                            if (value < E_38_U128) { // 37 <= n < 38.
+                                37
+                            } else { 38 }
+                        }
+                    }
                 }
             }
         }
@@ -184,7 +201,7 @@ module price::price {
 
     #[test]
     fun test_floored_log_10() {
-        // Test all constants up through E_38_U128.
+        // Test all powers of 10.
         assert!(floored_log_10(E_0_U128) == 0);
         assert!(floored_log_10(E_1_U128) == 1);
         assert!(floored_log_10(E_2_U128) == 2);
@@ -225,9 +242,88 @@ module price::price {
         assert!(floored_log_10(E_37_U128) == 37);
         assert!(floored_log_10(E_38_U128) == 38);
 
-        // u128 max
-        // each value + 1
-        // each value - 1
+        // Test one more than each power of 10.
+        assert!(floored_log_10(E_0_U128 + 1) == 0);
+        assert!(floored_log_10(E_1_U128 + 1) == 1);
+        assert!(floored_log_10(E_2_U128 + 1) == 2);
+        assert!(floored_log_10(E_3_U128 + 1) == 3);
+        assert!(floored_log_10(E_4_U128 + 1) == 4);
+        assert!(floored_log_10(E_5_U128 + 1) == 5);
+        assert!(floored_log_10(E_6_U128 + 1) == 6);
+        assert!(floored_log_10(E_7_U128 + 1) == 7);
+        assert!(floored_log_10(E_8_U128 + 1) == 8);
+        assert!(floored_log_10(E_9_U128 + 1) == 9);
+        assert!(floored_log_10(E_10_U128 + 1) == 10);
+        assert!(floored_log_10(E_11_U128 + 1) == 11);
+        assert!(floored_log_10(E_12_U128 + 1) == 12);
+        assert!(floored_log_10(E_13_U128 + 1) == 13);
+        assert!(floored_log_10(E_14_U128 + 1) == 14);
+        assert!(floored_log_10(E_15_U128 + 1) == 15);
+        assert!(floored_log_10(E_16_U128 + 1) == 16);
+        assert!(floored_log_10(E_17_U128 + 1) == 17);
+        assert!(floored_log_10(E_18_U128 + 1) == 18);
+        assert!(floored_log_10(E_19_U128 + 1) == 19);
+        assert!(floored_log_10(E_20_U128 + 1) == 20);
+        assert!(floored_log_10(E_21_U128 + 1) == 21);
+        assert!(floored_log_10(E_22_U128 + 1) == 22);
+        assert!(floored_log_10(E_23_U128 + 1) == 23);
+        assert!(floored_log_10(E_24_U128 + 1) == 24);
+        assert!(floored_log_10(E_25_U128 + 1) == 25);
+        assert!(floored_log_10(E_26_U128 + 1) == 26);
+        assert!(floored_log_10(E_27_U128 + 1) == 27);
+        assert!(floored_log_10(E_28_U128 + 1) == 28);
+        assert!(floored_log_10(E_29_U128 + 1) == 29);
+        assert!(floored_log_10(E_30_U128 + 1) == 30);
+        assert!(floored_log_10(E_31_U128 + 1) == 31);
+        assert!(floored_log_10(E_32_U128 + 1) == 32);
+        assert!(floored_log_10(E_33_U128 + 1) == 33);
+        assert!(floored_log_10(E_34_U128 + 1) == 34);
+        assert!(floored_log_10(E_35_U128 + 1) == 35);
+        assert!(floored_log_10(E_36_U128 + 1) == 36);
+        assert!(floored_log_10(E_37_U128 + 1) == 37);
+        assert!(floored_log_10(E_38_U128 + 1) == 38);
 
+        // Test one less than each power of 10.
+        assert!(floored_log_10(E_1_U128 - 1) == 0);
+        assert!(floored_log_10(E_2_U128 - 1) == 1);
+        assert!(floored_log_10(E_3_U128 - 1) == 2);
+        assert!(floored_log_10(E_4_U128 - 1) == 3);
+        assert!(floored_log_10(E_5_U128 - 1) == 4);
+        assert!(floored_log_10(E_6_U128 - 1) == 5);
+        assert!(floored_log_10(E_7_U128 - 1) == 6);
+        assert!(floored_log_10(E_8_U128 - 1) == 7);
+        assert!(floored_log_10(E_9_U128 - 1) == 8);
+        assert!(floored_log_10(E_10_U128 - 1) == 9);
+        assert!(floored_log_10(E_11_U128 - 1) == 10);
+        assert!(floored_log_10(E_12_U128 - 1) == 11);
+        assert!(floored_log_10(E_13_U128 - 1) == 12);
+        assert!(floored_log_10(E_14_U128 - 1) == 13);
+        assert!(floored_log_10(E_15_U128 - 1) == 14);
+        assert!(floored_log_10(E_16_U128 - 1) == 15);
+        assert!(floored_log_10(E_17_U128 - 1) == 16);
+        assert!(floored_log_10(E_18_U128 - 1) == 17);
+        assert!(floored_log_10(E_19_U128 - 1) == 18);
+        assert!(floored_log_10(E_20_U128 - 1) == 19);
+        assert!(floored_log_10(E_21_U128 - 1) == 20);
+        assert!(floored_log_10(E_22_U128 - 1) == 21);
+        assert!(floored_log_10(E_23_U128 - 1) == 22);
+        assert!(floored_log_10(E_24_U128 - 1) == 23);
+        assert!(floored_log_10(E_25_U128 - 1) == 24);
+        assert!(floored_log_10(E_26_U128 - 1) == 25);
+        assert!(floored_log_10(E_27_U128 - 1) == 26);
+        assert!(floored_log_10(E_28_U128 - 1) == 27);
+        assert!(floored_log_10(E_29_U128 - 1) == 28);
+        assert!(floored_log_10(E_30_U128 - 1) == 29);
+        assert!(floored_log_10(E_31_U128 - 1) == 30);
+        assert!(floored_log_10(E_32_U128 - 1) == 31);
+        assert!(floored_log_10(E_33_U128 - 1) == 32);
+        assert!(floored_log_10(E_34_U128 - 1) == 33);
+        assert!(floored_log_10(E_35_U128 - 1) == 34);
+        assert!(floored_log_10(E_36_U128 - 1) == 35);
+        assert!(floored_log_10(E_37_U128 - 1) == 36);
+        assert!(floored_log_10(E_38_U128 - 1) == 37);
+
+        // Test max value that can fit in a u128.
+        assert!(floored_log_10(U128_MAX) == 38);
     }
 }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -118,7 +118,7 @@ module price::price {
     /// as `0 <= n < 39`. Then the search range is bisected about the floored average of the
     /// endpoints: `(0 + 39) / 2 = 19`. This process yields two branches: `0 <= n < 19` and
     /// `19 <= n < 39`. The bisection process is repeated until the range is narrowed to a single
-    /// value, terminating the search in `log2(39) = 6` iterations or less.
+    /// value, terminating the search in `ceiling(log2(39)) = 6` iterations or less.
     public fun floored_log_10_with_max_power_leq(value: u128): (u32, u128) {
         assert!(value > 0, E_LOG_0_UNDEFINED);
         // 0 <= n < 39.

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -72,7 +72,7 @@ module price::price {
         assert!(base > 0, E_BASE_ZERO);
 
         let ratio_scaled = ((quote as u128) * DEC_MAX_U64_AS_U128) / (base as u128);
-        let log_10_ratio_scaled = floored_log_10(ratio_scaled);
+        let (log_10_ratio_scaled, last_power_of_10_scaled) = floored_log_10(ratio_scaled);
 
         // The base-10 logarithm of the ratio must be at least the minimum allowable exponent after
         // scaling back down:
@@ -88,38 +88,38 @@ module price::price {
         let exponent_encoded = log_10_ratio_scaled + EXPONENT_BIAS - EXP_MAX_U128;
         assert!(exponent_encoded <= (EXPONENT_MAX + EXPONENT_BIAS), E_TOO_LARGE_TO_REPRESENT);
 
-        1
     }
 
     #[view]
-    /// Return the floored base-10 logarithm of `value`. Uses binary search for speed, with each new
-    /// branch of the tree testing at the floored midpoint of the previous branch.
-    public fun floored_log_10(value: u128): u32 {
+    /// Return the floored base-10 logarithm of `value` and 10 raised to that power. Uses binary
+    /// search for speed, with each new branch of the tree testing at the floored midpoint of the
+    /// previous branch.
+    public fun floored_log_10(value: u128): (u32, u128) {
         assert!(value > 0, E_LOG_0_UNDEFINED);
         if (value < E_19_U128) { // 0 <= n < 19.
             if (value < E_9_U128) { // 0 <= n < 9.
                 if (value < E_4_U128) { // 0 <= n < 4.
                     if (value < E_2_U128) { // 0 <= n < 2.
                         if (value < E_1_U128) { // 0 <= n < 1.
-                            0
-                        } else { 1 }
+                            (0, E_0_U128)
+                        } else { (1, E_1_U128) }
                     } else { // 2 <= n < 4.
                         if (value < E_3_U128) { // 2 <= n < 3.
-                            2
-                        } else { 3 }
+                            (2, E_2_U128)
+                        } else { (3, E_3_U128) }
                     }
                 } else { // 4 <= n < 9.
                     if (value < E_6_U128) { // 4 <= n < 6.
                         if (value < E_5_U128) { // 4 <= n < 5.
-                            4
-                        } else { 5 }
+                            (4, E_4_U128)
+                        } else { (5, E_5_U128) }
                     } else { // 6 <= n < 9.
                         if (value < E_7_U128) { // 6 <= n < 7.
-                            6
+                            (6, E_6_U128)
                         } else { // 7 <= n < 9.
                             if (value < E_8_U128) { // 7 <= n < 8.
-                                7
-                            } else { 8 }
+                                (7, E_7_U128)
+                            } else { (8, E_8_U128) }
                         }
                     }
                 }
@@ -127,29 +127,29 @@ module price::price {
                 if (value < E_14_U128) { // 9 <= n < 14.
                     if (value < E_11_U128) { // 9 <= n < 11.
                         if (value < E_10_U128) { // 9 <= n < 10.
-                            9
-                        } else { 10 }
+                            (9, E_9_U128)
+                        } else { (10, E_10_U128) }
                     } else { // 11 <= n < 14.
                         if (value < E_12_U128) { // 11 <= n < 12.
-                            11
+                            (11, E_11_U128)
                         } else {
                             if (value < E_13_U128) { // 12 <= n < 13.
-                                12
-                            } else { 13 }
+                                (12, E_12_U128)
+                            } else { (13, E_13_U128) }
                         }
                     }
                 } else { // 14 <= n < 19.
                     if (value < E_16_U128) { // 14 <= n < 16.
                         if (value < E_15_U128) { // 14 <= n < 15.
-                            14
-                        } else { 15 }
+                            (14, E_14_U128)
+                        } else { (15, E_15_U128) }
                     } else { // 16 <= n < 19.
                        if (value < E_17_U128) { // 16 <= n < 17.
-                            16
+                            (16, E_16_U128)
                         } else { // 17 <= n < 19.
                             if (value < E_18_U128) { // 17 <= n < 18.
-                                17
-                            } else { 18 }
+                                (17, E_17_U128)
+                            } else { (18, E_18_U128) }
                         }
                     }
                 }
@@ -159,29 +159,29 @@ module price::price {
                 if (value < E_24_U128) { // 19 <= n < 24.
                     if (value < E_21_U128) { // 19 <= n < 21.
                         if (value < E_20_U128) { // 19 <= n < 20.
-                            19
-                        } else { 20 }
+                            (19, E_19_U128)
+                        } else { (20, E_20_U128) }
                     } else { // 21 <= n < 24.
                         if (value < E_22_U128) { // 21 <= n < 22.
-                            21
+                            (21, E_21_U128)
                         } else { // 22 <= n < 24.
                             if (value < E_23_U128) { // 22 <= n < 23.
-                                22
-                            } else { 23 }
+                                (22, E_22_U128)
+                            } else { (23, E_23_U128) }
                         }
                     }
                 } else { // 24 <= n < 29.
                     if (value < E_26_U128) { // 24 <= n < 26.
                         if (value < E_25_U128) { // 24 <= n < 25.
-                            24
-                        } else { 25 }
+                            (24, E_24_U128)
+                        } else { (25, E_25_U128) }
                     } else { // 26 <= n < 29.
                         if (value < E_27_U128) { // 26 <= n < 27.
-                            26
+                            (26, E_26_U128)
                         } else { // 27 <= n < 29.
                             if (value < E_28_U128) { // 27 <= n < 28.
-                                27
-                            } else { 28 }
+                                (27, E_27_U128)
+                            } else { (28, E_28_U128) }
                         }
                     }
                 }
@@ -189,29 +189,29 @@ module price::price {
                 if (value < E_34_U128) { // 29 <= n < 34.
                     if (value < E_31_U128) { // 29 <= n < 31.
                         if (value < E_30_U128) { // 29 <= n < 30.
-                            29
-                        } else { 30 }
+                            (29, E_29_U128)
+                        } else { (30, E_30_U128) }
                     } else { // 31 <= n < 34.
                         if (value < E_32_U128) { // 31 <= n < 32.
-                            31
+                            (31, E_31_U128)
                         } else { // 32 <= n < 34.
                             if (value < E_33_U128) { // 32 <= n < 33.
-                                32
-                            } else { 33 }
+                                (32, E_32_U128)
+                            } else { (33, E_33_U128) }
                         }
                     }
                 } else { // 34 <= n < 39.
                     if (value < E_36_U128) { // 34 <= n < 36.
                         if (value < E_35_U128) { // 34 <= n < 35.
-                            34
-                        } else { 35 }
+                            (34, E_34_U128)
+                        } else { (35, E_35_U128) }
                     } else { // 36 <= n < 39.
                         if (value < E_37_U128) { // 36 <= n < 37.
-                            36
+                            (36, E_36_U128)
                         } else { // 37 <= n < 39.
                             if (value < E_38_U128) { // 37 <= n < 38.
-                                37
-                            } else { 38 }
+                                (37, E_37_U128)
+                            } else { (38, E_38_U128) }
                         }
                     }
                 }
@@ -219,131 +219,138 @@ module price::price {
         }
     }
 
+    #[test_only]
+    fun assert_floored_log_10(value: u128, expected_log: u32, expected_power: u128) {
+        let (log, power) = floored_log_10(value);
+        assert!(log == expected_log, 1);
+        assert!(power == expected_power, 2);
+    }
+
     #[test]
     fun test_floored_log_10() {
         // Test all powers of 10.
-        assert!(floored_log_10(E_0_U128) == 0);
-        assert!(floored_log_10(E_1_U128) == 1);
-        assert!(floored_log_10(E_2_U128) == 2);
-        assert!(floored_log_10(E_3_U128) == 3);
-        assert!(floored_log_10(E_4_U128) == 4);
-        assert!(floored_log_10(E_5_U128) == 5);
-        assert!(floored_log_10(E_6_U128) == 6);
-        assert!(floored_log_10(E_7_U128) == 7);
-        assert!(floored_log_10(E_8_U128) == 8);
-        assert!(floored_log_10(E_9_U128) == 9);
-        assert!(floored_log_10(E_10_U128) == 10);
-        assert!(floored_log_10(E_11_U128) == 11);
-        assert!(floored_log_10(E_12_U128) == 12);
-        assert!(floored_log_10(E_13_U128) == 13);
-        assert!(floored_log_10(E_14_U128) == 14);
-        assert!(floored_log_10(E_15_U128) == 15);
-        assert!(floored_log_10(E_16_U128) == 16);
-        assert!(floored_log_10(E_17_U128) == 17);
-        assert!(floored_log_10(E_18_U128) == 18);
-        assert!(floored_log_10(E_19_U128) == 19);
-        assert!(floored_log_10(E_20_U128) == 20);
-        assert!(floored_log_10(E_21_U128) == 21);
-        assert!(floored_log_10(E_22_U128) == 22);
-        assert!(floored_log_10(E_23_U128) == 23);
-        assert!(floored_log_10(E_24_U128) == 24);
-        assert!(floored_log_10(E_25_U128) == 25);
-        assert!(floored_log_10(E_26_U128) == 26);
-        assert!(floored_log_10(E_27_U128) == 27);
-        assert!(floored_log_10(E_28_U128) == 28);
-        assert!(floored_log_10(E_29_U128) == 29);
-        assert!(floored_log_10(E_30_U128) == 30);
-        assert!(floored_log_10(E_31_U128) == 31);
-        assert!(floored_log_10(E_32_U128) == 32);
-        assert!(floored_log_10(E_33_U128) == 33);
-        assert!(floored_log_10(E_34_U128) == 34);
-        assert!(floored_log_10(E_35_U128) == 35);
-        assert!(floored_log_10(E_36_U128) == 36);
-        assert!(floored_log_10(E_37_U128) == 37);
-        assert!(floored_log_10(E_38_U128) == 38);
+        assert_floored_log_10(E_0_U128, 0, E_0_U128);
+        assert_floored_log_10(E_1_U128, 1, E_1_U128);
+        assert_floored_log_10(E_2_U128, 2, E_2_U128);
+        assert_floored_log_10(E_3_U128, 3, E_3_U128);
+        assert_floored_log_10(E_4_U128, 4, E_4_U128);
+        assert_floored_log_10(E_5_U128, 5, E_5_U128);
+        assert_floored_log_10(E_6_U128, 6, E_6_U128);
+        assert_floored_log_10(E_7_U128, 7, E_7_U128);
+        assert_floored_log_10(E_8_U128, 8, E_8_U128);
+        assert_floored_log_10(E_9_U128, 9, E_9_U128);
+        assert_floored_log_10(E_10_U128, 10, E_10_U128);
+        assert_floored_log_10(E_11_U128, 11, E_11_U128);
+        assert_floored_log_10(E_12_U128, 12, E_12_U128);
+        assert_floored_log_10(E_13_U128, 13, E_13_U128);
+        assert_floored_log_10(E_14_U128, 14, E_14_U128);
+        assert_floored_log_10(E_15_U128, 15, E_15_U128);
+        assert_floored_log_10(E_16_U128, 16, E_16_U128);
+        assert_floored_log_10(E_17_U128, 17, E_17_U128);
+        assert_floored_log_10(E_18_U128, 18, E_18_U128);
+        assert_floored_log_10(E_19_U128, 19, E_19_U128);
+        assert_floored_log_10(E_20_U128, 20, E_20_U128);
+        assert_floored_log_10(E_21_U128, 21, E_21_U128);
+        assert_floored_log_10(E_22_U128, 22, E_22_U128);
+        assert_floored_log_10(E_23_U128, 23, E_23_U128);
+        assert_floored_log_10(E_24_U128, 24, E_24_U128);
+        assert_floored_log_10(E_25_U128, 25, E_25_U128);
+        assert_floored_log_10(E_26_U128, 26, E_26_U128);
+        assert_floored_log_10(E_27_U128, 27, E_27_U128);
+        assert_floored_log_10(E_28_U128, 28, E_28_U128);
+        assert_floored_log_10(E_29_U128, 29, E_29_U128);
+        assert_floored_log_10(E_30_U128, 30, E_30_U128);
+        assert_floored_log_10(E_31_U128, 31, E_31_U128);
+        assert_floored_log_10(E_32_U128, 32, E_32_U128);
+        assert_floored_log_10(E_33_U128, 33, E_33_U128);
+        assert_floored_log_10(E_34_U128, 34, E_34_U128);
+        assert_floored_log_10(E_35_U128, 35, E_35_U128);
+        assert_floored_log_10(E_36_U128, 36, E_36_U128);
+        assert_floored_log_10(E_37_U128, 37, E_37_U128);
+        assert_floored_log_10(E_38_U128, 38, E_38_U128);
 
         // Test one more than each power of 10.
-        assert!(floored_log_10(E_0_U128 + 1) == 0);
-        assert!(floored_log_10(E_1_U128 + 1) == 1);
-        assert!(floored_log_10(E_2_U128 + 1) == 2);
-        assert!(floored_log_10(E_3_U128 + 1) == 3);
-        assert!(floored_log_10(E_4_U128 + 1) == 4);
-        assert!(floored_log_10(E_5_U128 + 1) == 5);
-        assert!(floored_log_10(E_6_U128 + 1) == 6);
-        assert!(floored_log_10(E_7_U128 + 1) == 7);
-        assert!(floored_log_10(E_8_U128 + 1) == 8);
-        assert!(floored_log_10(E_9_U128 + 1) == 9);
-        assert!(floored_log_10(E_10_U128 + 1) == 10);
-        assert!(floored_log_10(E_11_U128 + 1) == 11);
-        assert!(floored_log_10(E_12_U128 + 1) == 12);
-        assert!(floored_log_10(E_13_U128 + 1) == 13);
-        assert!(floored_log_10(E_14_U128 + 1) == 14);
-        assert!(floored_log_10(E_15_U128 + 1) == 15);
-        assert!(floored_log_10(E_16_U128 + 1) == 16);
-        assert!(floored_log_10(E_17_U128 + 1) == 17);
-        assert!(floored_log_10(E_18_U128 + 1) == 18);
-        assert!(floored_log_10(E_19_U128 + 1) == 19);
-        assert!(floored_log_10(E_20_U128 + 1) == 20);
-        assert!(floored_log_10(E_21_U128 + 1) == 21);
-        assert!(floored_log_10(E_22_U128 + 1) == 22);
-        assert!(floored_log_10(E_23_U128 + 1) == 23);
-        assert!(floored_log_10(E_24_U128 + 1) == 24);
-        assert!(floored_log_10(E_25_U128 + 1) == 25);
-        assert!(floored_log_10(E_26_U128 + 1) == 26);
-        assert!(floored_log_10(E_27_U128 + 1) == 27);
-        assert!(floored_log_10(E_28_U128 + 1) == 28);
-        assert!(floored_log_10(E_29_U128 + 1) == 29);
-        assert!(floored_log_10(E_30_U128 + 1) == 30);
-        assert!(floored_log_10(E_31_U128 + 1) == 31);
-        assert!(floored_log_10(E_32_U128 + 1) == 32);
-        assert!(floored_log_10(E_33_U128 + 1) == 33);
-        assert!(floored_log_10(E_34_U128 + 1) == 34);
-        assert!(floored_log_10(E_35_U128 + 1) == 35);
-        assert!(floored_log_10(E_36_U128 + 1) == 36);
-        assert!(floored_log_10(E_37_U128 + 1) == 37);
-        assert!(floored_log_10(E_38_U128 + 1) == 38);
+        assert_floored_log_10(E_0_U128 + 1, 0, E_0_U128);
+        assert_floored_log_10(E_1_U128 + 1, 1, E_1_U128);
+        assert_floored_log_10(E_2_U128 + 1, 2, E_2_U128);
+        assert_floored_log_10(E_3_U128 + 1, 3, E_3_U128);
+        assert_floored_log_10(E_4_U128 + 1, 4, E_4_U128);
+        assert_floored_log_10(E_5_U128 + 1, 5, E_5_U128);
+        assert_floored_log_10(E_6_U128 + 1, 6, E_6_U128);
+        assert_floored_log_10(E_7_U128 + 1, 7, E_7_U128);
+        assert_floored_log_10(E_8_U128 + 1, 8, E_8_U128);
+        assert_floored_log_10(E_9_U128 + 1, 9, E_9_U128);
+        assert_floored_log_10(E_10_U128 + 1, 10, E_10_U128);
+        assert_floored_log_10(E_11_U128 + 1, 11, E_11_U128);
+        assert_floored_log_10(E_12_U128 + 1, 12, E_12_U128);
+        assert_floored_log_10(E_13_U128 + 1, 13, E_13_U128);
+        assert_floored_log_10(E_14_U128 + 1, 14, E_14_U128);
+        assert_floored_log_10(E_15_U128 + 1, 15, E_15_U128);
+        assert_floored_log_10(E_16_U128 + 1, 16, E_16_U128);
+        assert_floored_log_10(E_17_U128 + 1, 17, E_17_U128);
+        assert_floored_log_10(E_18_U128 + 1, 18, E_18_U128);
+        assert_floored_log_10(E_19_U128 + 1, 19, E_19_U128);
+        assert_floored_log_10(E_20_U128 + 1, 20, E_20_U128);
+        assert_floored_log_10(E_21_U128 + 1, 21, E_21_U128);
+        assert_floored_log_10(E_22_U128 + 1, 22, E_22_U128);
+        assert_floored_log_10(E_23_U128 + 1, 23, E_23_U128);
+        assert_floored_log_10(E_24_U128 + 1, 24, E_24_U128);
+        assert_floored_log_10(E_25_U128 + 1, 25, E_25_U128);
+        assert_floored_log_10(E_26_U128 + 1, 26, E_26_U128);
+        assert_floored_log_10(E_27_U128 + 1, 27, E_27_U128);
+        assert_floored_log_10(E_28_U128 + 1, 28, E_28_U128);
+        assert_floored_log_10(E_29_U128 + 1, 29, E_29_U128);
+        assert_floored_log_10(E_30_U128 + 1, 30, E_30_U128);
+        assert_floored_log_10(E_31_U128 + 1, 31, E_31_U128);
+        assert_floored_log_10(E_32_U128 + 1, 32, E_32_U128);
+        assert_floored_log_10(E_33_U128 + 1, 33, E_33_U128);
+        assert_floored_log_10(E_34_U128 + 1, 34, E_34_U128);
+        assert_floored_log_10(E_35_U128 + 1, 35, E_35_U128);
+        assert_floored_log_10(E_36_U128 + 1, 36, E_36_U128);
+        assert_floored_log_10(E_37_U128 + 1, 37, E_37_U128);
+        assert_floored_log_10(E_38_U128 + 1, 38, E_38_U128);
 
         // Test one less than each power of 10.
-        assert!(floored_log_10(E_1_U128 - 1) == 0);
-        assert!(floored_log_10(E_2_U128 - 1) == 1);
-        assert!(floored_log_10(E_3_U128 - 1) == 2);
-        assert!(floored_log_10(E_4_U128 - 1) == 3);
-        assert!(floored_log_10(E_5_U128 - 1) == 4);
-        assert!(floored_log_10(E_6_U128 - 1) == 5);
-        assert!(floored_log_10(E_7_U128 - 1) == 6);
-        assert!(floored_log_10(E_8_U128 - 1) == 7);
-        assert!(floored_log_10(E_9_U128 - 1) == 8);
-        assert!(floored_log_10(E_10_U128 - 1) == 9);
-        assert!(floored_log_10(E_11_U128 - 1) == 10);
-        assert!(floored_log_10(E_12_U128 - 1) == 11);
-        assert!(floored_log_10(E_13_U128 - 1) == 12);
-        assert!(floored_log_10(E_14_U128 - 1) == 13);
-        assert!(floored_log_10(E_15_U128 - 1) == 14);
-        assert!(floored_log_10(E_16_U128 - 1) == 15);
-        assert!(floored_log_10(E_17_U128 - 1) == 16);
-        assert!(floored_log_10(E_18_U128 - 1) == 17);
-        assert!(floored_log_10(E_19_U128 - 1) == 18);
-        assert!(floored_log_10(E_20_U128 - 1) == 19);
-        assert!(floored_log_10(E_21_U128 - 1) == 20);
-        assert!(floored_log_10(E_22_U128 - 1) == 21);
-        assert!(floored_log_10(E_23_U128 - 1) == 22);
-        assert!(floored_log_10(E_24_U128 - 1) == 23);
-        assert!(floored_log_10(E_25_U128 - 1) == 24);
-        assert!(floored_log_10(E_26_U128 - 1) == 25);
-        assert!(floored_log_10(E_27_U128 - 1) == 26);
-        assert!(floored_log_10(E_28_U128 - 1) == 27);
-        assert!(floored_log_10(E_29_U128 - 1) == 28);
-        assert!(floored_log_10(E_30_U128 - 1) == 29);
-        assert!(floored_log_10(E_31_U128 - 1) == 30);
-        assert!(floored_log_10(E_32_U128 - 1) == 31);
-        assert!(floored_log_10(E_33_U128 - 1) == 32);
-        assert!(floored_log_10(E_34_U128 - 1) == 33);
-        assert!(floored_log_10(E_35_U128 - 1) == 34);
-        assert!(floored_log_10(E_36_U128 - 1) == 35);
-        assert!(floored_log_10(E_37_U128 - 1) == 36);
-        assert!(floored_log_10(E_38_U128 - 1) == 37);
+        assert_floored_log_10(E_1_U128 - 1, 0, E_0_U128);
+        assert_floored_log_10(E_2_U128 - 1, 1, E_1_U128);
+        assert_floored_log_10(E_3_U128 - 1, 2, E_2_U128);
+        assert_floored_log_10(E_4_U128 - 1, 3, E_3_U128);
+        assert_floored_log_10(E_5_U128 - 1, 4, E_4_U128);
+        assert_floored_log_10(E_6_U128 - 1, 5, E_5_U128);
+        assert_floored_log_10(E_7_U128 - 1, 6, E_6_U128);
+        assert_floored_log_10(E_8_U128 - 1, 7, E_7_U128);
+        assert_floored_log_10(E_9_U128 - 1, 8, E_8_U128);
+        assert_floored_log_10(E_10_U128 - 1, 9, E_9_U128);
+        assert_floored_log_10(E_11_U128 - 1, 10, E_10_U128);
+        assert_floored_log_10(E_12_U128 - 1, 11, E_11_U128);
+        assert_floored_log_10(E_13_U128 - 1, 12, E_12_U128);
+        assert_floored_log_10(E_14_U128 - 1, 13, E_13_U128);
+        assert_floored_log_10(E_15_U128 - 1, 14, E_14_U128);
+        assert_floored_log_10(E_16_U128 - 1, 15, E_15_U128);
+        assert_floored_log_10(E_17_U128 - 1, 16, E_16_U128);
+        assert_floored_log_10(E_18_U128 - 1, 17, E_17_U128);
+        assert_floored_log_10(E_19_U128 - 1, 18, E_18_U128);
+        assert_floored_log_10(E_20_U128 - 1, 19, E_19_U128);
+        assert_floored_log_10(E_21_U128 - 1, 20, E_20_U128);
+        assert_floored_log_10(E_22_U128 - 1, 21, E_21_U128);
+        assert_floored_log_10(E_23_U128 - 1, 22, E_22_U128);
+        assert_floored_log_10(E_24_U128 - 1, 23, E_23_U128);
+        assert_floored_log_10(E_25_U128 - 1, 24, E_24_U128);
+        assert_floored_log_10(E_26_U128 - 1, 25, E_25_U128);
+        assert_floored_log_10(E_27_U128 - 1, 26, E_26_U128);
+        assert_floored_log_10(E_28_U128 - 1, 27, E_27_U128);
+        assert_floored_log_10(E_29_U128 - 1, 28, E_28_U128);
+        assert_floored_log_10(E_30_U128 - 1, 29, E_29_U128);
+        assert_floored_log_10(E_31_U128 - 1, 30, E_30_U128);
+        assert_floored_log_10(E_32_U128 - 1, 31, E_31_U128);
+        assert_floored_log_10(E_33_U128 - 1, 32, E_32_U128);
+        assert_floored_log_10(E_34_U128 - 1, 33, E_33_U128);
+        assert_floored_log_10(E_35_U128 - 1, 34, E_34_U128);
+        assert_floored_log_10(E_36_U128 - 1, 35, E_35_U128);
+        assert_floored_log_10(E_37_U128 - 1, 36, E_36_U128);
+        assert_floored_log_10(E_38_U128 - 1, 37, E_37_U128);
 
         // Test max value that can fit in a u128.
-        assert!(floored_log_10(U128_MAX) == 38);
+        assert_floored_log_10(U128_MAX, 38, E_38_U128);
     }
 }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -59,6 +59,46 @@ module price::price {
     const E_37: u128 = 10_000_000_000_000_000_000_000_000_000_000_000_000;
     const E_38: u128 = 100_000_000_000_000_000_000_000_000_000_000_000_000;
 
+    const N_0: u32 = 0;
+    const N_1: u32 = 1;
+    const N_2: u32 = 2;
+    const N_3: u32 = 3;
+    const N_4: u32 = 4;
+    const N_5: u32 = 5;
+    const N_6: u32 = 6;
+    const N_7: u32 = 7;
+    const N_8: u32 = 8;
+    const N_9: u32 = 9;
+    const N_10: u32 = 10;
+    const N_11: u32 = 11;
+    const N_12: u32 = 12;
+    const N_13: u32 = 13;
+    const N_14: u32 = 14;
+    const N_15: u32 = 15;
+    const N_16: u32 = 16;
+    const N_17: u32 = 17;
+    const N_18: u32 = 18;
+    const N_19: u32 = 19;
+    const N_20: u32 = 20;
+    const N_21: u32 = 21;
+    const N_22: u32 = 22;
+    const N_23: u32 = 23;
+    const N_24: u32 = 24;
+    const N_25: u32 = 25;
+    const N_26: u32 = 26;
+    const N_27: u32 = 27;
+    const N_28: u32 = 28;
+    const N_29: u32 = 29;
+    const N_30: u32 = 30;
+    const N_31: u32 = 31;
+    const N_32: u32 = 32;
+    const N_33: u32 = 33;
+    const N_34: u32 = 34;
+    const N_35: u32 = 35;
+    const N_36: u32 = 36;
+    const N_37: u32 = 37;
+    const N_38: u32 = 38;
+
     /// Base term is 0.
     const E_BASE_ZERO: u64 = 1;
     /// Logarithm of 0 is undefined.

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -1,0 +1,233 @@
+module price::price {
+
+    /// The largest power of 10 that can fit in a `u64`, as a `u128`.
+    /// In Python: `f"{10 ** (math.floor(math.log10(2 ** 64 - 1))):_}"`
+    const DEC_MAX_U64_AS_U128: u128 = 10_000_000_000_000_000_000;
+    /// The exponent of the largest power of 10 that can fit in a `u64`.
+    /// In Python: `math.floor(math.log10(2 ** 64 - 1))`
+    const EXP_MAX_U64: u32 = 19;
+    /// The exponent of the largest power of 10 that can fit in a `u128`.
+    /// In Python: `math.floor(math.log10(2 ** 128 - 1))`
+    const EXP_MAX_U128: u32 = 38;
+
+    const E_0_U128: u128 = 1;
+    const E_1_U128: u128 = 10;
+    const E_2_U128: u128 = 100;
+    const E_3_U128: u128 = 1_000;
+    const E_4_U128: u128 = 10_000;
+    const E_5_U128: u128 = 100_000;
+    const E_6_U128: u128 = 1_000_000;
+    const E_7_U128: u128 = 10_000_000;
+    const E_8_U128: u128 = 100_000_000;
+    const E_9_U128: u128 = 1_000_000_000;
+    const E_10_U128: u128 = 10_000_000_000;
+    const E_11_U128: u128 = 100_000_000_000;
+    const E_12_U128: u128 = 1_000_000_000_000;
+    const E_13_U128: u128 = 10_000_000_000_000;
+    const E_14_U128: u128 = 100_000_000_000_000;
+    const E_15_U128: u128 = 1_000_000_000_000_000;
+    const E_16_U128: u128 = 10_000_000_000_000_000;
+    const E_17_U128: u128 = 100_000_000_000_000_000;
+    const E_18_U128: u128 = 1_000_000_000_000_000_000;
+    const E_19_U128: u128 = 10_000_000_000_000_000_000;
+    const E_20_U128: u128 = 100_000_000_000_000_000_000;
+    const E_21_U128: u128 = 1_000_000_000_000_000_000_000;
+    const E_22_U128: u128 = 10_000_000_000_000_000_000_000;
+    const E_23_U128: u128 = 100_000_000_000_000_000_000_000;
+    const E_24_U128: u128 = 1_000_000_000_000_000_000_000_000;
+    const E_25_U128: u128 = 10_000_000_000_000_000_000_000_000;
+    const E_26_U128: u128 = 100_000_000_000_000_000_000_000_000;
+    const E_27_U128: u128 = 1_000_000_000_000_000_000_000_000_000;
+    const E_28_U128: u128 = 10_000_000_000_000_000_000_000_000_000;
+    const E_29_U128: u128 = 100_000_000_000_000_000_000_000_000_000;
+    const E_30_U128: u128 = 1_000_000_000_000_000_000_000_000_000_000;
+    const E_31_U128: u128 = 10_000_000_000_000_000_000_000_000_000_000;
+    const E_32_U128: u128 = 100_000_000_000_000_000_000_000_000_000_000;
+    const E_33_U128: u128 = 1_000_000_000_000_000_000_000_000_000_000_000;
+    const E_34_U128: u128 = 10_000_000_000_000_000_000_000_000_000_000_000;
+    const E_35_U128: u128 = 100_000_000_000_000_000_000_000_000_000_000_000;
+    const E_36_U128: u128 = 1_000_000_000_000_000_000_000_000_000_000_000_000;
+    const E_37_U128: u128 = 10_000_000_000_000_000_000_000_000_000_000_000_000;
+    const E_38_U128: u128 = 100_000_000_000_000_000_000_000_000_000_000_000_000;
+
+    /// Base term is 0.
+    const E_BASE_ZERO: u64 = 1;
+
+    /*
+    #[view]
+    /// Return the canonical price for a given ratio of base and quote.
+    public fun price(base: u64, quote: u64): u32 {
+        assert!(base > 0, E_BASE_ZERO);
+
+        let ratio_scaled = ((quote as u128) * DEC_MAX_U64_AS_U128) / (base as u128);
+        let exponent_scaled = floored_log_10(ratio_scaled);
+
+        let significand = first_8_sig_figs(ratio_scaled);
+        1
+    }
+    */
+
+    #[view]
+    /// Return the floored base-10 logarithm of `value`. Uses binary search for speed, with each new
+    /// branch of the tree testing at the floored midpoint of the previous branch.
+    public fun floored_log_10(value: u128): u32 {
+        if (value < E_19_U128) { // 0 <= n < 19.
+            if (value < E_9_U128) { // 0 <= n < 9.
+                if (value < E_4_U128) { // 0 <= n < 4.
+                    if (value < E_2_U128) { // 0 <= n < 2.
+                        if (value < E_1_U128) { // 0 <= n < 1.
+                            0
+                        } else { 1 }
+                    } else { // 2 <= n < 4.
+                        if (value < E_3_U128) { // 2 <= n < 3.
+                            2
+                        } else { 3 }
+                    }
+                } else { // 4 <= n < 9.
+                    if (value < E_6_U128) { // 4 <= n < 6.
+                        if (value < E_5_U128) { // 4 <= n < 5.
+                            4
+                        } else { 5 }
+                    } else { // 6 <= n < 9.
+                        if (value < E_7_U128) { // 6 <= n < 7.
+                            6
+                        } else { // 7 <= n < 9.
+                            if (value < E_8_U128) { // 7 <= n < 8.
+                                7
+                            } else { 8 }
+                        }
+                    }
+                }
+            } else { // 9 <= n < 19.
+                if (value < E_14_U128) { // 9 <= n < 14.
+                    if (value < E_12_U128) { // 9 <= n < 12.
+                        if (value < E_10_U128) { // 9 <= n < 10.
+                            9
+                        } else { // 10 <= n < 12.
+                            if (value < E_11_U128) { // 10 <= n < 11.
+                                10
+                            } else { 11 }
+                        }
+                    } else { // 12 <= n < 14.
+                        if (value < E_13_U128) { // 12 <= n < 13.
+                            12
+                        } else { 13 }
+                    }
+                } else { // 14 <= n < 19.
+                    if (value < E_16_U128) { // 14 <= n < 16.
+                        if (value < E_15_U128) { // 14 <= n < 15.
+                            14
+                        } else { 15 }
+                    } else { // 16 <= n < 19.
+                       if (value < E_17_U128) { // 16 <= n < 17.
+                            16
+                        } else { // 17 <= n < 19.
+                            if (value < E_18_U128) { // 17 <= n < 18.
+                                17
+                            } else { 18 }
+                        }
+                    }
+                }
+            }
+        } else { // 19 <= n < 39.
+            if (value < E_29_U128) { // 19 <= n < 29.
+                if (value < E_24_U128) { // 19 <= n < 24.
+                    if (value < E_21_U128) { // 19 <= n < 21.
+                        if (value < E_20_U128) { // 19 <= n < 20.
+                            19
+                        } else { 20 }
+                    } else { // 21 <= n < 24.
+                        if (value < E_22_U128) { // 21 <= n < 22.
+                            21
+                        } else { // 22 <= n < 24.
+                            if (value < E_23_U128) { // 22 <= n < 23.
+                                22
+                            } else { 23 }
+                        }
+                    }
+                } else { // 24 <= n < 29.
+                    if (value < E_26_U128) { // 24 <= n < 26.
+                        if (value < E_25_U128) { // 24 <= n < 25.
+                            24
+                        } else { 25 }
+                    } else { // 26 <= n < 29.
+                        if (value < E_27_U128) { // 26 <= n < 27.
+                            26
+                        } else { // 27 <= n < 29.
+                            if (value < E_28_U128) { // 27 <= n < 28.
+                                27
+                            } else { 28 }
+                        }
+                    }
+                }
+            } else { // 29 <= n < 39.
+                if (value < E_34_U128) { // 29 <= n < 34.
+                    if (value < E_31_U128) { // 29 <= n < 31.
+                        if (value < E_30_U128) { // 29 <= n < 30.
+                            29
+                        } else { 30 }
+                    } else { // 31 <= n < 34.
+                        if (value < E_32_U128) { // 31 <= n < 32.
+                            31
+                        } else { // 32 <= n < 34.
+                            if (value < E_33_U128) { // 32 <= n < 33.
+                                32
+                            } else { 33 }
+                        }
+                    }
+                } else { // 34 <= n < 39.
+                    16
+                }
+            }
+        }
+    }
+
+    #[test]
+    fun test_floored_log_10() {
+        // Test all constants up through E_38_U128.
+        assert!(floored_log_10(E_0_U128) == 0);
+        assert!(floored_log_10(E_1_U128) == 1);
+        assert!(floored_log_10(E_2_U128) == 2);
+        assert!(floored_log_10(E_3_U128) == 3);
+        assert!(floored_log_10(E_4_U128) == 4);
+        assert!(floored_log_10(E_5_U128) == 5);
+        assert!(floored_log_10(E_6_U128) == 6);
+        assert!(floored_log_10(E_7_U128) == 7);
+        assert!(floored_log_10(E_8_U128) == 8);
+        assert!(floored_log_10(E_9_U128) == 9);
+        assert!(floored_log_10(E_10_U128) == 10);
+        assert!(floored_log_10(E_11_U128) == 11);
+        assert!(floored_log_10(E_12_U128) == 12);
+        assert!(floored_log_10(E_13_U128) == 13);
+        assert!(floored_log_10(E_14_U128) == 14);
+        assert!(floored_log_10(E_15_U128) == 15);
+        assert!(floored_log_10(E_16_U128) == 16);
+        assert!(floored_log_10(E_17_U128) == 17);
+        assert!(floored_log_10(E_18_U128) == 18);
+        assert!(floored_log_10(E_19_U128) == 19);
+        assert!(floored_log_10(E_20_U128) == 20);
+        assert!(floored_log_10(E_21_U128) == 21);
+        assert!(floored_log_10(E_22_U128) == 22);
+        assert!(floored_log_10(E_23_U128) == 23);
+        assert!(floored_log_10(E_24_U128) == 24);
+        assert!(floored_log_10(E_25_U128) == 25);
+        assert!(floored_log_10(E_26_U128) == 26);
+        assert!(floored_log_10(E_27_U128) == 27);
+        assert!(floored_log_10(E_28_U128) == 28);
+        assert!(floored_log_10(E_29_U128) == 29);
+        assert!(floored_log_10(E_30_U128) == 30);
+        assert!(floored_log_10(E_31_U128) == 31);
+        assert!(floored_log_10(E_32_U128) == 32);
+        assert!(floored_log_10(E_33_U128) == 33);
+        assert!(floored_log_10(E_34_U128) == 34);
+        assert!(floored_log_10(E_35_U128) == 35);
+        assert!(floored_log_10(E_36_U128) == 36);
+        assert!(floored_log_10(E_37_U128) == 37);
+        assert!(floored_log_10(E_38_U128) == 38);
+
+        // u128 max
+        // each value + 1
+        // each value - 1
+
+    }
+}

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -11,6 +11,8 @@ module price::price {
     const EXP_MAX_U128: u32 = 38;
     /// The largest `u128` value. In Python: `f"{2 ** 128 - 1:_}"`
     const U128_MAX: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
+    /// The bias for the exponent of the canonical price encoding.
+    const EXPONENT_BIAS: u32 = 16;
 
     const E_0_U128: u128 = 1;
     const E_1_U128: u128 = 10;
@@ -59,12 +61,14 @@ module price::price {
 
     /*
     #[view]
-    /// Return the canonical price for a given ratio of base and quote.
+    /// Return the canonical price encoding for a given ratio of base and quote.
     public fun price(base: u64, quote: u64): u32 {
         assert!(base > 0, E_BASE_ZERO);
 
         let ratio_scaled = ((quote as u128) * DEC_MAX_U64_AS_U128) / (base as u128);
         let exponent_scaled = floored_log_10(ratio_scaled);
+
+        assert!()
 
         let significand = first_8_sig_figs(ratio_scaled);
         1
@@ -105,18 +109,18 @@ module price::price {
                 }
             } else { // 9 <= n < 19.
                 if (value < E_14_U128) { // 9 <= n < 14.
-                    if (value < E_12_U128) { // 9 <= n < 12.
+                    if (value < E_11_U128) { // 9 <= n < 11.
                         if (value < E_10_U128) { // 9 <= n < 10.
                             9
-                        } else { // 10 <= n < 12.
-                            if (value < E_11_U128) { // 10 <= n < 11.
-                                10
-                            } else { 11 }
+                        } else { 10 }
+                    } else { // 11 <= n < 14.
+                        if (value < E_12_U128) { // 11 <= n < 12.
+                            11
+                        } else {
+                            if (value < E_13_U128) { // 12 <= n < 13.
+                                12
+                            } else { 13 }
                         }
-                    } else { // 12 <= n < 14.
-                        if (value < E_13_U128) { // 12 <= n < 13.
-                            12
-                        } else { 13 }
                     }
                 } else { // 14 <= n < 19.
                     if (value < E_16_U128) { // 14 <= n < 16.

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -118,7 +118,7 @@ module price::price {
     /// as `0 <= n < 39`. Then the search range is bisected about the floored average of the
     /// endpoints: `(0 + 39) / 2 = 19`. This process yields two branches: `0 <= n < 19` and
     /// `19 <= n < 39`. The bisection process is repeated until the range is narrowed to a single
-    /// value, terminating the search.
+    /// value, terminating the search in `log2(39) = 6` iterations or less.
     public fun floored_log_10_with_max_power_leq(value: u128): (u32, u128) {
         assert!(value > 0, E_LOG_0_UNDEFINED);
         // 0 <= n < 39.

--- a/src/move/research/price/sources/red_black_map.move
+++ b/src/move/research/price/sources/red_black_map.move
@@ -1,0 +1,3 @@
+module price::price {
+
+}

--- a/src/move/research/price/sources/red_black_map.move
+++ b/src/move/research/price/sources/red_black_map.move
@@ -1,3 +1,0 @@
-module price::price {
-
-}

--- a/src/move/research/uniswap-v3-book-milestone-1/README.md
+++ b/src/move/research/uniswap-v3-book-milestone-1/README.md
@@ -152,7 +152,7 @@ aptos move test --filter calculating_liquidity
 ### `calculating_liquidity`
 
 For simplicity the original section does not properly account for USDC decimals,
-and instead uses $10^{18}$ for both ETH and USDC subunits.  Hence, for target
+and instead uses $10^{18}$ for both ETH and USDC subunits. Hence, for target
 deposit amounts the example uses 1,000,000 base subunits and 5,000,000,000 for
 quote subunits to ensure adequate precision.
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

## Econia canonical price

1. Add detailed README on design.
1. Add preliminary implementation to get Econia canonical price from a ratio of
   base and quote.
1. Add tests to 100% coverage

## Housekeeping

1. Update `pre-commit` config with `mdformat` options to support LaTex,
   prettified `cspell` escapes.
1. Run new version of `mdformat`, thus formatting out extra spaces in:
    1. `architecture-specification.md`.
    1. `CONTRIBUTING.md`.
    1. A UniSwap v3 `README`.
1. Remove `--move-2` flag from CLI commands now that it is standard in CLI.
1. Add `significand` to `cspell` dictionary.

# Testing

Tested to 100% coverage from inside `/src/move/research/price`:

```sh
git ls-files | entr -c sh -c " \
       aptos move test --coverage --dev &&
       aptos move fmt
   "
```

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)