### PR TITLE
[ECO-2670] Price special values, helpers, quote API

### DIFF
--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -40,6 +40,17 @@ The minimum and maximum representable nonzero prices are thus:
 | Minimum | $p_{min}$ | $1 \cdot 10^{-16}$        |
 | Maximum | $p_{max}$ | $9.9999999 \cdot 10^{15}$ |
 
+## Special versus regular values
+
+$0$ and $\infty$ are considered "special" values and are represented as follows:
+
+| Value    | Symbol       | Encoding     |
+| -------- | ------------ | ------------ |
+| $0$      | $p_0$        | `0x0`        |
+| $\infty$ | $p_{\infty}$ | `0xffffffff` |
+
+This contrasts with all other representable values, which are denoted "regular".
+
 ## Encoding
 
 The 27 significand bits can theoretically encode any natural number $n$ for

--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -1,3 +1,5 @@
+<!--- cspell:word infty -->
+
 # Econia canonical price
 
 ## General

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -376,7 +376,7 @@ module price::price {
     /// Returns the power of 10 for a canonical exponent, using similar binary search as
     /// `floored_log_10_with_max_power_leq()`.
     public fun power_of_10(exponent: u32): u128 {
-        assert!(exponent <= N_16, E_INVALID_EXPONENT);
+        assert!(exponent < N_17, E_INVALID_EXPONENT);
         // 0 <= n < 17.
         if (exponent < N_8) { // 0 <= n < 8.
             if (exponent < N_4) { // 0 <= n < 4.
@@ -400,8 +400,32 @@ module price::price {
                     } else { E_7 }
                 }
             }
-        } else { // 9 <= n < 17.
-            0
+        } else { // 8 <= n < 17.
+            if (exponent < N_12) { // 8 <= n < 12.
+                if (exponent < N_10) { // 8 <= n < 10.
+                    if (exponent < N_9) { // 8 <= n < 9.
+                        E_8
+                    } else { E_9 }
+                } else { // 10 <= n < 12.
+                    if (exponent < N_11) { // 10 <= n < 11.
+                        E_10
+                    } else { E_11 }
+                }
+            } else { // 12 <= n < 17.
+                if (exponent < N_14) { // 12 <= n < 14.
+                    if (exponent < N_13) { // 12 <= n < 13.
+                        E_12
+                    } else { E_13 }
+                } else { // 14 <= n < 17.
+                    if (exponent < N_15) { // 14 <= n < 15.
+                        E_14
+                    } else { // 15 <= n < 17.
+                        if (exponent < N_16) { // 15 <= n < 16.
+                            E_15
+                        } else { E_16 }
+                    }
+                }
+            }
         }
     }
 

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -17,7 +17,7 @@ module price::price {
 
     /// Maximum allowed significand for a regular price.
     const M_MAX: u32 = 99_999_999;
-    /// Minimum allowed significand for a regular price.
+    /// Minimum allowed significand for a regular price. Same as `E_7` but as a `u32` for speed.
     const M_MIN: u32 = 10_000_000;
 
     const E_0: u128 = 1;
@@ -701,6 +701,18 @@ module price::price {
         assert!(is_regular(price));
         assert!(!is_special(price));
         assert!(!is_zero(price));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_INVALID_PRICE)]
+    public fun test_normlized_exponent_magnitude_invalid_price() {
+        normalized_exponent_magnitude(infinity());
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_INVALID_PRICE)]
+    public fun test_normlized_exponent_is_positive_invalid_price() {
+        normalized_exponent_is_positive(infinity());
     }
 
     #[test]

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -737,6 +737,30 @@ module price::price {
     }
 
     #[test]
+    #[expected_failure(abort_code = E_INVALID_EXPONENT_NEGATIVE)]
+    public fun test_price_from_terms_invalid_exponent_negative() {
+        price_from_terms((E_7 as u32), N_17, false);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_INVALID_EXPONENT_POSITIVE)]
+    public fun test_price_from_terms_invalid_exponent_positive() {
+        price_from_terms((E_7 as u32), N_16, true);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_INVALID_SIGNIFICAND_HI)]
+    public fun test_price_from_terms_invalid_significand_hi() {
+        price_from_terms(M_MAX + 1, N_15, true);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_INVALID_SIGNIFICAND_LO)]
+    public fun test_price_from_terms_invalid_significand_lo() {
+        price_from_terms(M_MIN - 1, N_15, true);
+    }
+
+    #[test]
     #[expected_failure(abort_code = E_TOO_LARGE_TO_REPRESENT)]
     public fun test_price_too_large_to_represent() {
         // Price 9.9999999 * 10^16
@@ -775,6 +799,10 @@ module price::price {
                 normalized_exponent_is_positive
             ) == price
         );
+        assert!(normalized_exponent_magnitude(price) == normalized_exponent_magnitude);
+        assert!(
+            normalized_exponent_is_positive(price) == normalized_exponent_is_positive
+        );
 
         // Price 8.7654321 * 10^-12
         base = 10_000_000_000_000_000_000;
@@ -794,6 +822,10 @@ module price::price {
                 normalized_exponent_magnitude,
                 normalized_exponent_is_positive
             ) == price
+        );
+        assert!(normalized_exponent_magnitude(price) == normalized_exponent_magnitude);
+        assert!(
+            normalized_exponent_is_positive(price) == normalized_exponent_is_positive
         );
 
         // Price 5.0000000 * 10^-16
@@ -815,6 +847,10 @@ module price::price {
                 normalized_exponent_is_positive
             ) == price
         );
+        assert!(normalized_exponent_magnitude(price) == normalized_exponent_magnitude);
+        assert!(
+            normalized_exponent_is_positive(price) == normalized_exponent_is_positive
+        );
 
         // Price 9.9999999 * 10^15
         base = 1_000;
@@ -832,6 +868,10 @@ module price::price {
                 normalized_exponent_magnitude,
                 normalized_exponent_is_positive
             ) == price
+        );
+        assert!(normalized_exponent_magnitude(price) == normalized_exponent_magnitude);
+        assert!(
+            normalized_exponent_is_positive(price) == normalized_exponent_is_positive
         );
 
         // Price 1.0000000 * 10^-16
@@ -853,6 +893,10 @@ module price::price {
                 normalized_exponent_is_positive
             ) == price
         );
+        assert!(normalized_exponent_magnitude(price) == normalized_exponent_magnitude);
+        assert!(
+            normalized_exponent_is_positive(price) == normalized_exponent_is_positive
+        );
 
         // Price 9.7900000 * 10^1
         base = 2_000_000;
@@ -872,6 +916,10 @@ module price::price {
                 normalized_exponent_magnitude,
                 normalized_exponent_is_positive
             ) == price
+        );
+        assert!(normalized_exponent_magnitude(price) == normalized_exponent_magnitude);
+        assert!(
+            normalized_exponent_is_positive(price) == normalized_exponent_is_positive
         );
 
     }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -8,6 +8,16 @@ module price::price {
     /// In Python: `hex(int('1' * 27, 2))`.
     const HI_SIGNIFICAND: u32 = 0x7ffffff;
 
+    /// Special price zero.
+    const P_ZERO: u32 = 0;
+    /// Special price infinity, all bits set in `u32`. In Python: `hex(int('1' * 32, 2))`
+    const P_INFINITY: u32 = 0xffffffff;
+
+    /// Maximum allowed significand for a finite, nonzero price.
+    const M_MAX: u32 = 99_999_999;
+    /// Minimum allowed significand for a finite, nonzero price.
+    const M_MIN: u32 = 10_000_000;
+
     const E_0: u128 = 1;
     const E_1: u128 = 10;
     const E_2: u128 = 100;
@@ -103,7 +113,7 @@ module price::price {
     }
 
     #[view]
-    public fun encoded_price(price: u32): u32 {
+    public fun encoded_significand(price: u32): u32 {
         price & HI_SIGNIFICAND
     }
 
@@ -275,6 +285,32 @@ module price::price {
                 }
             }
         }
+    }
+
+    #[view]
+    public fun is_canonical(price: u32): bool {
+        is_regular(price) || is_regular(price)
+    }
+
+    #[view]
+    public fun is_infinity(price: u32): bool {
+        price == P_INFINITY
+    }
+
+    #[view]
+    public fun is_regular(price: u32): bool {
+        let significand = encoded_significand(price);
+        significand >= M_MIN && significand <= M_MAX
+    }
+
+    #[view]
+    public fun is_special(price: u32): bool {
+        is_infinity(price) || is_zero(price)
+    }
+
+    #[view]
+    public fun is_zero(price: u32): bool {
+        price == P_ZERO
     }
 
     #[view]
@@ -468,42 +504,42 @@ module price::price {
         let quote = 294_837_500_000;
         let price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 + 7);
-        assert!(encoded_price(price) == 12_500_000);
+        assert!(encoded_significand(price) == 12_500_000);
 
         // Price 8.7654321 * 10^-12
         base = 10_000_000_000_000_000_000;
         quote = 87_654_321;
         price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 - 12);
-        assert!(encoded_price(price) == 87_654_321);
+        assert!(encoded_significand(price) == 87_654_321);
 
         // Price 5.0000000 * 10^-16
         base = 2_000_000_000_000_000_000;
         quote = 1_000;
         price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 - 16);
-        assert!(encoded_price(price) == 50_000_000);
+        assert!(encoded_significand(price) == 50_000_000);
 
         // Price 9.9999999 * 10^15
         base = 1_000;
         quote = 9_999_999_900_000_000_000;
         price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 + 15);
-        assert!(encoded_price(price) == 99_999_999);
+        assert!(encoded_significand(price) == 99_999_999);
 
         // Price 1.0000000 * 10^-16
         base = 2_000_000_000_000_000_000;
         quote = 200;
         price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 - 16);
-        assert!(encoded_price(price) == 10_000_000);
+        assert!(encoded_significand(price) == 10_000_000);
 
         // Price 9.7900000 * 10^1
         base = 2_000_000;
         quote = 195_800_000;
         price = price(base, quote);
         assert!(encoded_exponent(price) == N_16 + 1);
-        assert!(encoded_price(price) == 97_900_000);
+        assert!(encoded_significand(price) == 97_900_000);
     }
 
     #[test]

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -705,13 +705,13 @@ module price::price {
 
     #[test]
     #[expected_failure(abort_code = E_INVALID_PRICE)]
-    public fun test_normlized_exponent_magnitude_invalid_price() {
+    public fun test_normalized_exponent_magnitude_invalid_price() {
         normalized_exponent_magnitude(infinity());
     }
 
     #[test]
     #[expected_failure(abort_code = E_INVALID_PRICE)]
-    public fun test_normlized_exponent_is_positive_invalid_price() {
+    public fun test_normalized_exponent_is_positive_invalid_price() {
         normalized_exponent_is_positive(infinity());
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add "special" prices 0 and infinity to the standard.
1. Add assorted helpers for extracting encodings, inspecting special cases.
1. Add `power_of_10` function for canonical exponents.
1. Add `quote` API for convering `{base, price}` to quote value.
and why they were necessary.

# Testing

Tested to 100% coverage from inside `/src/move/research/price`:

```sh
git ls-files | entr -c sh -c " \
       aptos move test --coverage --dev &&
       aptos move fmt
   "
```

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check off all checkboxes from the linked Linear task?