### PR TITLE
[ECO-2704] Finalize Econia Canonical Price APIs

### DIFF
--- a/src/move/research/price/README.md
+++ b/src/move/research/price/README.md
@@ -15,7 +15,8 @@ Prices are denoted using an unsigned [normalized number] format, so at current
 market prices as of the time of this writing, for example, the ratio of $9.79$
 `USD` per $1$ `APT` would be denoted $p = 9.79 \cdot 10^1$. (This example
 assumes a hypothetical `USD` asset with the same number of `Coin` decimals as
-`APT`, since the implementation operates on indivisible subunits).
+`APT`, since the implementation operates on indivisible subunits, e.g.
+`Coin.value`).
 
 $$
 p = \frac{9.79}{1} = 9.79 \cdot 10^1

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -1221,7 +1221,7 @@ module price::price {
                     )
                 );
             };
-            // Check total order for significands within the current exponent.
+            // Check total order for minimum and maximum significand at current exponent.
             assert!(
                 price_from_terms(
                     M_MIN,

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -1176,4 +1176,10 @@ module price::price {
         let base = (MAX_U64 as u64);
         quote(base, price);
     }
+
+    #[test]
+    #[expected_failure(abort_code = E_INVALID_PRICE)]
+    public fun test_ratio_invalid_price() {
+        ratio(infinity());
+    }
 }

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -1,5 +1,7 @@
 module price::price {
 
+    use aptos_std::math128;
+
     /// The largest `u128` value. In Python: `f"{int('1' * 128, 2):_}"`.
     const MAX_U128: u128 = 340_282_366_920_938_463_463_374_607_431_768_211_455;
     /// The largest `u64` value. In Python: `f"{int('1' * 64, 2):_}"`.
@@ -642,6 +644,14 @@ module price::price {
     }
 
     #[view]
+    /// Like `ratio()`, but irreducibly reduced.
+    public fun ratio_irreducible(price: u32): (u128, u128) {
+        let (base, quote) = ratio(price);
+        let greatest_common_denominator = math128::gcd(base, quote);
+        (base / greatest_common_denominator, quote / greatest_common_denominator)
+    }
+
+    #[view]
     public fun zero(): u32 {
         P_ZERO
     }
@@ -972,6 +982,9 @@ module price::price {
         assert!(
             quote_ratio == (quote((base_ratio as u64), price) as u128)
         );
+        let (base_ratio_irreducible, quote_ratio_irreducible) = ratio_irreducible(price);
+        assert!(base_ratio_irreducible == base_ratio);
+        assert!(quote_ratio_irreducible == quote_ratio);
 
         // Price 8.7654321 * 10^-12
         base = 10_000_000_000_000_000_000;
@@ -997,11 +1010,14 @@ module price::price {
             normalized_exponent_is_positive(price) == normalized_exponent_is_positive
         );
         assert!(base(quote, price) == base);
-        let (base_ratio, quote_ratio) = ratio(price);
+        (base_ratio, quote_ratio) = ratio(price);
         assert!(base_ratio == E_19);
         assert!(
             quote_ratio == (quote((base_ratio as u64), price) as u128)
         );
+        (base_ratio_irreducible, quote_ratio_irreducible) = ratio_irreducible(price);
+        assert!(base_ratio_irreducible == base_ratio);
+        assert!(quote_ratio_irreducible == quote_ratio);
 
         // Price 5.0000000 * 10^-16
         base = 2_000_000_000_000_000_000;
@@ -1030,6 +1046,9 @@ module price::price {
         let (base_ratio, quote_ratio) = ratio(price);
         assert!(base_ratio == E_23);
         assert!(quote_ratio == (significand_digits as u128));
+        (base_ratio_irreducible, quote_ratio_irreducible) = ratio_irreducible(price);
+        assert!(base_ratio_irreducible == 2 * E_15);
+        assert!(quote_ratio_irreducible == 1);
 
         // Price 9.9999999 * 10^15
         base = 1_000;
@@ -1058,6 +1077,9 @@ module price::price {
         assert!(
             quote_ratio == (quote((base_ratio as u64), price) as u128)
         );
+        (base_ratio_irreducible, quote_ratio_irreducible) = ratio_irreducible(price);
+        assert!(base_ratio_irreducible == base_ratio);
+        assert!(quote_ratio_irreducible == quote_ratio);
 
         // Price 1.0000000 * 10^-16
         base = 2_000_000_000_000_000_000;
@@ -1086,6 +1108,9 @@ module price::price {
         let (base_ratio, quote_ratio) = ratio(price);
         assert!(base_ratio == E_23);
         assert!(quote_ratio == (significand_digits as u128));
+        (base_ratio_irreducible, quote_ratio_irreducible) = ratio_irreducible(price);
+        assert!(base_ratio_irreducible == E_16);
+        assert!(quote_ratio_irreducible == 1);
 
         // Price 9.7900000 * 10^1
         base = 2_000_000;
@@ -1116,6 +1141,9 @@ module price::price {
         assert!(
             quote_ratio == (quote((base_ratio as u64), price) as u128)
         );
+        (base_ratio_irreducible, quote_ratio_irreducible) = ratio_irreducible(price);
+        assert!(base_ratio_irreducible == E_1);
+        assert!(quote_ratio_irreducible == 979);
 
     }
 

--- a/src/move/research/price/sources/price.move
+++ b/src/move/research/price/sources/price.move
@@ -524,12 +524,12 @@ module price::price {
         assert!(floored_log_10_ratio_e19 <= N_34, E_TOO_LARGE_TO_REPRESENT);
 
         // The encoded exponent is the floored base-10 logarithm of the scaled ratio, incremented
-        // by the bias (16), then decremented by the maximum power of 10 that can fit in a `u64`
-        // (19). This is equivalent to decrementing by 3.
+        // by the bias (16), then decremented by the scalar from earlier, the maximum power of 10
+        // that can fit in a `u64` (19). This is equivalent to decrementing by 3.
         let encoded_exponent = floored_log_10_ratio_e19 - N_3;
 
-        // If scaled ratio is smaller than `E_7`, it must be right-padded to yield a canonicalized
-        // significand with 8 significant digits.
+        // If scaled ratio is smaller than `E_7`, it must be right-padded with zeroes to yield a
+        // canonicalized significand with 8 significant digits.
         let encoded_significand =
             if (ratio_e19 < E_7) {
                 ratio_e19 * (E_7 / max_power_10_leq_ratio_e19)


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

# Finalize Econia price APIs

- [X] Create `ratio` helper for getting an exact ratio.
- [X] Create `ratio_irreducible` helper for irreducible fraction.
- [X] Standardize algorithm flow across `base`, `quote`, `ratio` helpers.
- [X] Add total order test.
- [X] Add `Coin.value` note to README.
- [X] Annotate special powers of 10.


# Testing

Tested to 100% coverage from inside `/src/move/research/price`:

```sh
git ls-files | entr -c sh -c " \
    aptos move test --coverage --dev &&
    aptos move fmt
"
```

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you add tests to cover new code or a fixed issue?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
