### PR TITLE
[ECO-2675] Define fee assessment styles

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -7,6 +7,7 @@ econia
 forall
 octas
 precommit
+posteriori
 significand
 struct
 structs

--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -6,8 +6,8 @@ collateralized
 econia
 forall
 octas
-precommit
 posteriori
+precommit
 significand
 struct
 structs

--- a/src/move/research/fee/Move.toml
+++ b/src/move/research/fee/Move.toml
@@ -1,0 +1,18 @@
+[addresses]
+price = '_'
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "mainnet"
+subdir = "aptos-framework"
+
+[dev-addresses]
+price = '0xabc'
+
+[dev-dependencies]
+
+[package]
+authors = ["Econia Labs (developers@econialabs.com)"]
+name = "Price"
+upgrade_policy = "compatible"
+version = "0.1.0"

--- a/src/move/research/fee/Move.toml
+++ b/src/move/research/fee/Move.toml
@@ -1,5 +1,5 @@
 [addresses]
-price = '_'
+fee = '_'
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-framework.git"
@@ -7,12 +7,12 @@ rev = "mainnet"
 subdir = "aptos-framework"
 
 [dev-addresses]
-price = '0xabc'
+fee = '0xabc'
 
 [dev-dependencies]
 
 [package]
 authors = ["Econia Labs (developers@econialabs.com)"]
-name = "Price"
+name = "Fee"
 upgrade_policy = "compatible"
 version = "0.1.0"

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -25,6 +25,15 @@ $$
 f = \frac{f_{\%}}{100} V = \frac{f_i}{1,000,000} V
 $$
 
+Note the following definition of volume:
+
+> Volume is defined as the change in asset holdings experienced by the liquidity
+> provider (maker) of a trade, independent of fees paid by the swapper (taker).
+> This assumes makers do not pay a fee on provided liquidity.
+
+For example if a taker's quote input amount is 105 quote subunits, 5 of which is
+charged as fees and 100 of which is credited to the maker, quote volume is 100.
+
 ## Input and output assets
 
 The input and output asset for a taker order (simple swap) is as follows:

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -36,8 +36,8 @@ Note the following definition of volume:
 > This assumes makers do not pay a fee on provided liquidity.
 
 For example if a taker's quote input amount is 105 quote subunits, 5 of which
-are charged as fees and 100 of which are credited to the maker, quote volume is
-100. Since fees are set aside *before* matching, this is an a priori fee.
+are charged as fees and 100 of which are credited to the maker, the quote volume
+is 100. Since fees are set aside *before* matching, this is an a priori fee.
 
 Conversely, if filling against a maker yields 100 base subunits, 5 of which are
 charged as fees and 95 of which are credited to the taker, base volume is 100.

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -11,10 +11,10 @@ asset ("a posteriori fee").
 ## Notation and units
 
 This implementation measures fee rates in $\frac{1}{100}$ of a basis point. For
-example a $1$ percent nominal fee percentage $f_p = 1$ corresponds to an integer
-fee rate of $f_i = 10,000$. Notably, fee rates can thus be encoded as a `u16`
-with a maximum rate of $\frac{2^{16} - 1}{10,000} = 6.5535$ percent, with the
-conversion from nominal fee rate percentage to integer fee rate as follows:
+example a $1$% fee rate $f_p = 1$ corresponds to an integer fee rate of
+$f_i = 10,000$. Notably, fee rates can thus be encoded as a `u16` with a maximum
+rate of $\frac{2^{16} - 1}{10,000} = 6.5535$%, with the conversion from fee rate
+percentage to integer fee rate as follows:
 
 $$
 \begin{aligned}
@@ -76,9 +76,9 @@ $$
 
 #### Example
 
-Consider a swap sell with $f_p = 0.5$ percent fees assessed in the quote asset,
-where the maker yields $V = 40,000$ quote subunits after filling against the
-base input from the swapper. The integer fee rate $f_i$:
+Consider a swap sell with $f_p = 0.5$% fees assessed in the quote asset, where
+the maker yields $V = 40,000$ quote subunits after filling against the base
+input from the swapper. The integer fee rate $f_i$:
 
 $$
 \begin{aligned}
@@ -144,9 +144,9 @@ $$
 
 #### Example
 
-Consider a swap buy with $f_p = 1.5$ percent fees assessed in the quote asset,
-where the swapper has $I = 20,300$ subunits available as an input. The integer
-fee rate $f_i$:
+Consider a swap buy with $f_p = 1.5$% fees assessed in the quote asset, where
+the swapper has $I = 20,300$ subunits available as an input. The integer fee
+rate $f_i$:
 
 $$
 \begin{aligned}

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -11,7 +11,7 @@ asset ("a posteriori fee").
 ## Notation and units
 
 This implementation measures fee rates in $\frac{1}{100}$ of a basis point. For
-example a $1\%$ nominal fee percentage $f_{\%} = 1\%$ corresponds to an integer
+example a $ 1\% $ nominal fee percentage $f_{\%} = 1\%$ corresponds to an integer
 fee rate of $f_i = 10,000$. Notably, fee rates can thus be encoded as a `u16`
 with a maximum rate of $\frac{2^{16} - 1}{10,000} = 6.5535\%$, with the
 conversion from nominal fee rate percentage to integer fee rate as follows:

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -2,10 +2,10 @@
 
 ## Base and quote
 
-Fees can be assessed as a proportion of either size (base subunits) or volume
-(quote subunits) depending on the fee collector's preferred asset. As such there
-are two equations for determining the fee assessed on any given trade, based on
-whether the source asset (base or quote) is the input or output asset.
+Fees can be assessed as a proportion of either base volume or quote volume
+depending on the fee collector's preferred asset. As such there are two
+equations for determining the fee assessed on any given trade, based on whether
+the source asset (base or quote) is the input or output asset.
 
 ## Notation and units
 
@@ -19,6 +19,12 @@ $$
 f_{\%} = \frac{f_i}{10,000}\%
 $$
 
+Thus to assess a fee $f$ on some volume $V$:
+
+$$
+f = \frac{f_{\%}}{100} V = \frac{f_i}{1,000,000} V
+$$
+
 ## Input and output assets
 
 The input and output asset for a taker order (simple swap) is as follows:
@@ -27,3 +33,64 @@ The input and output asset for a taker order (simple swap) is as follows:
 | ---- | ----------- | ------------ |
 | Buy  | Quote       | Base         |
 | Sell | Base        | Quote        |
+
+### Output as source
+
+The output asset is the fee source for the two following scenarios:
+
+1. A swap sell with fees assessed in the quote asset.
+1. A swap buy with fees denominated in the base asset.
+
+That is, all of the input asset is used to match against the maker position,
+then a portion of the proceeds (volume) is taken as a fee.
+
+### Input as source
+
+The input asset is the fee source for the two following scenarios:
+
+1. A swap buy with fees assessed in the quote asset.
+1. A swap sell with fees denominated in the base asset.
+
+That is, a portion of the input asset must be set aside to cover fees, then the
+remainder (volume) can be used to fill against a maker position. Consider input
+amount $I$ of source asset, comprised of volume $V$ and fee $f$:
+
+$$
+\begin{aligned}
+I &= V + f \\
+I &= V + \frac{f_i}{1,000,000} V \\
+I &= V \left( 1 + \frac{f_i}{1,000,000} \right) \\
+I &= V \left( \frac{1,000,000}{1,000,000} + \frac{f_i}{1,000,000} \right) \\
+I &= V \left( \frac{1,000,000 + f_i}{1,000,000} \right) \\
+I \left( \frac{1,000,000}{1,000,000 + f_i} \right) &= V \\
+\end{aligned}
+$$
+
+Thus, solving for $f$:
+
+$$
+\begin{aligned}
+f &= \frac{f_i}{1,000,000} V  \\
+f &= \frac{f_i}{1,000,000} I \left( \frac{1,000,000}{1,000,000 + f_i} \right) \\
+f &= \frac{f_i I }{1,000,000 + f_i}
+\end{aligned}
+$$
+
+For example, consider a swap buy with $f_{\%} = 1.5\%$ fees assessed in the
+quote asset, where the user has $I = 20,003$ subunits available as an input:
+
+$$
+\begin{aligned}
+V &= 20,003 \left( \frac{1,000,000}{1,000,000 + 150} \right) \\
+V &= 20,000
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+f &= \frac{150}{1,000,000} 20,000  \\
+f &= 3
+\end{aligned}
+$$
+
+The same solution holds for a swap sell with fees assessed in the base asset.

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -5,8 +5,8 @@
 Fees can be assessed as a proportion of either base volume or quote volume
 depending on the fee collector's preferred asset. As such there are two
 equations for determining the fee assessed on any given trade, based on whether
-the source asset (base or quote) is the input asset ("a priori fees") or output
-asset ("a posteriori fees").
+the source asset (base or quote) is the input asset ("a priori fee") or output
+asset ("a posteriori fee").
 
 ## Notation and units
 
@@ -57,7 +57,7 @@ The input and output asset for a taker order (simple swap) is as follows:
 The output asset is the fee source for the two following scenarios:
 
 1. A swap sell with fees assessed in the quote asset.
-1. A swap buy with fees denominated in the base asset.
+1. A swap buy with fees assessed in the base asset.
 
 That is, all of the input asset is credited to the maker, then a portion of the
 asset yielded by the maker (volume) is taken as a fee. Consider volume $V$
@@ -115,7 +115,7 @@ The same solution holds for a swap buy with fees assessed in the base asset.
 The input asset is the fee source for the two following scenarios:
 
 1. A swap buy with fees assessed in the quote asset.
-1. A swap sell with fees denominated in the base asset.
+1. A swap sell with fees assessed in the base asset.
 
 That is, a portion of the input asset must be set aside to cover fees, then the
 remainder (volume) can be used to fill against a maker position. Consider input

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -5,7 +5,8 @@
 Fees can be assessed as a proportion of either base volume or quote volume
 depending on the fee collector's preferred asset. As such there are two
 equations for determining the fee assessed on any given trade, based on whether
-the source asset (base or quote) is the input or output asset.
+the source asset (base or quote) is the input asset ("a priori fees") or output
+asset ("a posteriori fees").
 
 ## Notation and units
 
@@ -16,7 +17,10 @@ with a maximum rate of $\frac{2^{16} - 1}{10,000} = 6.5535\%$, with the
 conversion from nominal fee rate percentage to integer fee rate as follows:
 
 $$
-f_{\%} = \frac{f_i}{10,000}\%
+\begin{aligned}
+f_{\%} &= \frac{f_i}{10,000} \\
+f_i &= 10,000 f_{\%}
+\end{aligned}
 $$
 
 Thus to assess a fee $f$ on some volume $V$:
@@ -31,8 +35,13 @@ Note the following definition of volume:
 > provider (maker) of a trade, independent of fees paid by the swapper (taker).
 > This assumes makers do not pay a fee on provided liquidity.
 
-For example if a taker's quote input amount is 105 quote subunits, 5 of which is
-charged as fees and 100 of which is credited to the maker, quote volume is 100.
+For example if a taker's quote input amount is 105 quote subunits, 5 of which
+are charged as fees and 100 of which are credited to the maker, quote volume is
+100. Since fees are set aside *before* matching, this is an a priori fee.
+
+Conversely, if filling against a maker yields 100 base subunits, 5 of which are
+charged as fees and 95 of which are credited to the taker, base volume is 100.
+Since fees are assessed *after* matching, this is an a posteriori fee.
 
 ## Input and output assets
 
@@ -43,17 +52,65 @@ The input and output asset for a taker order (simple swap) is as follows:
 | Buy  | Quote       | Base         |
 | Sell | Base        | Quote        |
 
-### Output as source
+### A posteriori fees
 
 The output asset is the fee source for the two following scenarios:
 
 1. A swap sell with fees assessed in the quote asset.
 1. A swap buy with fees denominated in the base asset.
 
-That is, all of the input asset is used to match against the maker position,
-then a portion of the proceeds (volume) is taken as a fee.
+That is, all of the input asset is credited to the maker, then a portion of the
+asset yielded by the maker (volume) is taken as a fee. Consider volume $V$
+yielded by the maker, comprised of $P$ proceeds to the taker and fee $f$:
 
-### Input as source
+$$
+\begin{aligned}
+P + f &= V \\
+P + \frac{f_i}{1,000,000} V &= V \\
+P &= V - \frac{f_i}{1,000,000} V \\
+P &= V \left( 1 - \frac{f_i}{1,000,000} \right) \\
+P &= V \left( \frac{1,000,000}{1,000,000} - \frac{f_i}{1,000,000} \right) \\
+P&= V \left( \frac{1,000,000 - f_i}{1,000,000} \right)
+\end{aligned}
+$$
+
+#### Example
+
+Consider a swap sell with $f_{\%} = 0.5\%$ fees assessed in the quote asset,
+where the maker yields $V = 40,000$ quote subunits after filling against the
+base input from the swapper. The integer fee rate $f_i$:
+
+$$
+\begin{aligned}
+f_i &= 10,000 f_{\%} \\
+f_i &= 10,000 \cdot 0.5 \\
+f_i &= 5,000
+\end{aligned}
+$$
+
+The actual fee $f$:
+
+$$
+\begin{aligned}
+f &= \frac{f_i}{1,000,000} V \\
+f &= \frac{5,000}{1,000,000} 40,000 \\
+f &= 200
+\end{aligned}
+$$
+
+The proceeds $P$ to the taker:
+
+$$
+\begin{aligned}
+P&= V \left( \frac{1,000,000 - f_i}{1,000,000} \right) \\
+P&= 40,000 \left( \frac{1,000,000 - 5,000}{1,000,000} \right) \\
+P&= 39,800
+\end{aligned}
+$$
+
+The same solution holds for a swap buy with fees assessed in the base asset.
+
+### A priori fees
 
 The input asset is the fee source for the two following scenarios:
 
@@ -66,12 +123,12 @@ amount $I$ of source asset, comprised of volume $V$ and fee $f$:
 
 $$
 \begin{aligned}
-I &= V + f \\
-I &= V + \frac{f_i}{1,000,000} V \\
-I &= V \left( 1 + \frac{f_i}{1,000,000} \right) \\
-I &= V \left( \frac{1,000,000}{1,000,000} + \frac{f_i}{1,000,000} \right) \\
-I &= V \left( \frac{1,000,000 + f_i}{1,000,000} \right) \\
-I \left( \frac{1,000,000}{1,000,000 + f_i} \right) &= V \\
+V + f &= I \\
+V + \frac{f_i}{1,000,000} V &= I \\
+V \left( 1 + \frac{f_i}{1,000,000} \right) &= I \\
+V \left( \frac{1,000,000}{1,000,000} + \frac{f_i}{1,000,000} \right) &= I \\
+V \left( \frac{1,000,000 + f_i}{1,000,000} \right) &= I \\
+V &= \left( \frac{1,000,000}{1,000,000 + f_i} \right) I
 \end{aligned}
 $$
 
@@ -80,25 +137,42 @@ Thus, solving for $f$:
 $$
 \begin{aligned}
 f &= \frac{f_i}{1,000,000} V  \\
-f &= \frac{f_i}{1,000,000} I \left( \frac{1,000,000}{1,000,000 + f_i} \right) \\
+f &= \frac{f_i}{1,000,000} \left( \frac{1,000,000}{1,000,000 + f_i} \right) I \\
 f &= \frac{f_i I }{1,000,000 + f_i}
 \end{aligned}
 $$
 
-For example, consider a swap buy with $f_{\%} = 1.5\%$ fees assessed in the
-quote asset, where the user has $I = 20,003$ subunits available as an input:
+#### Example
+
+Consider a swap buy with $f_{\%} = 1.5\%$ fees assessed in the quote asset,
+where the swapper has $I = 20,300$ subunits available as an input.
+The integer fee rate $f_i$:
 
 $$
 \begin{aligned}
-V &= 20,003 \left( \frac{1,000,000}{1,000,000 + 150} \right) \\
+f_i &= 10,000 f_{\%} \\
+f_i &= 10,000 \cdot 1.5 \\
+f_i &= 15,000
+\end{aligned}
+$$
+
+The volume $V$ credited to the maker:
+
+$$
+\begin{aligned}
+V &= \left( \frac{1,000,000}{1,000,000 + f_i} \right) I \\
+V &= \left( \frac{1,000,000}{1,000,000 + 15,000} \right) 20,300 \\
 V &= 20,000
 \end{aligned}
 $$
 
+The fee $f$ paid by the taker:
+
 $$
 \begin{aligned}
-f &= \frac{150}{1,000,000} 20,000  \\
-f &= 3
+f &= \frac{f_i I }{1,000,000 + f_i} \\
+f &= \frac{15,000 \cdot 20,300 }{1,000,000 + 15,000} \\
+f &= 300
 \end{aligned}
 $$
 

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -11,22 +11,22 @@ asset ("a posteriori fee").
 ## Notation and units
 
 This implementation measures fee rates in $\frac{1}{100}$ of a basis point. For
-example a $ 1\% $ nominal fee percentage $f_{\%} = 1\%$ corresponds to an integer
+example a $1$ percent nominal fee percentage $f_p = 1$ corresponds to an integer
 fee rate of $f_i = 10,000$. Notably, fee rates can thus be encoded as a `u16`
-with a maximum rate of $\frac{2^{16} - 1}{10,000} = 6.5535\%$, with the
+with a maximum rate of $\frac{2^{16} - 1}{10,000} = 6.5535$ percent, with the
 conversion from nominal fee rate percentage to integer fee rate as follows:
 
 $$
 \begin{aligned}
-f_{\%} &= \frac{f_i}{10,000} \\
-f_i &= 10,000 f_{\%}
+f_p &= \frac{f_i}{10,000} \\
+f_i &= 10,000 f_p
 \end{aligned}
 $$
 
 Thus to assess a fee $f$ on some volume $V$:
 
 $$
-f = \frac{f_{\%}}{100} V = \frac{f_i}{1,000,000} V
+f = \frac{f_p}{100} V = \frac{f_i}{1,000,000} V
 $$
 
 Note the following definition of volume:
@@ -76,13 +76,13 @@ $$
 
 #### Example
 
-Consider a swap sell with $f_{\%} = 0.5\%$ fees assessed in the quote asset,
+Consider a swap sell with $f_p = 0.5$ percent fees assessed in the quote asset,
 where the maker yields $V = 40,000$ quote subunits after filling against the
 base input from the swapper. The integer fee rate $f_i$:
 
 $$
 \begin{aligned}
-f_i &= 10,000 f_{\%} \\
+f_i &= 10,000 f_p \\
 f_i &= 10,000 \cdot 0.5 \\
 f_i &= 5,000
 \end{aligned}
@@ -144,13 +144,13 @@ $$
 
 #### Example
 
-Consider a swap buy with $f_{\%} = 1.5\%$ fees assessed in the quote asset,
-where the swapper has $I = 20,300$ subunits available as an input.
-The integer fee rate $f_i$:
+Consider a swap buy with $f_p = 1.5$ percent fees assessed in the quote asset,
+where the swapper has $I = 20,300$ subunits available as an input. The integer
+fee rate $f_i$:
 
 $$
 \begin{aligned}
-f_i &= 10,000 f_{\%} \\
+f_i &= 10,000 f_p \\
 f_i &= 10,000 \cdot 1.5 \\
 f_i &= 15,000
 \end{aligned}

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -1,0 +1,29 @@
+# Fees
+
+## Base and quote
+
+Fees can be assessed as a proportion of either size (base subunits) or volume
+(quote subunits) depending on the fee collector's preferred asset. As such there
+are two equations for determining the fee assessed on any given trade, based on
+whether the source asset (base or quote) is the input or output asset.
+
+## Notation and units
+
+This implementation measures fee rates in $\frac{1}{100}$ of a basis point. For
+example a $1\%$ nominal fee percentage $f_{\%} = 1\%$ corresponds to an integer
+fee rate of $f_i = 10,000$. Notably, fee rates can thus be encoded as a `u16`
+with a maximum rate of $\frac{2^{16} - 1}{10,000} = 6.5535\%$, with the
+conversion from nominal fee rate percentage to integer fee rate as follows:
+
+$$
+f_{\%} = \frac{f_i}{10,000}\%
+$$
+
+## Input and output assets
+
+The input and output asset for a taker order (simple swap) is as follows:
+
+| Side | Input asset | Output asset |
+| ---- | ----------- | ------------ |
+| Buy  | Quote       | Base         |
+| Sell | Base        | Quote        |

--- a/src/move/research/fee/README.md
+++ b/src/move/research/fee/README.md
@@ -13,8 +13,8 @@ asset ("a posteriori fee").
 This implementation measures fee rates in $\frac{1}{100}$ of a basis point. For
 example a $1$% fee rate $f_p = 1$ corresponds to an integer fee rate of
 $f_i = 10,000$. Notably, fee rates can thus be encoded as a `u16` with a maximum
-rate of $\frac{2^{16} - 1}{10,000} = 6.5535$%, with the conversion from fee rate
-percentage to integer fee rate as follows:
+rate of $\frac{2^{16} - 1}{10,000} =$ $6.5535$%, with the conversion from fee
+rate percentage to integer fee rate as follows:
 
 $$
 \begin{aligned}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add README defining a priori and a posteriori fees.
2. Create a stub package `Move.toml`.
3. Add `posteriori` to dictionary file.

# Testing

CI passes

# Checklist

- [x] Did you update relevant documentation?
- [x] Did you check off all checkboxes from the linked Linear task? (Ignore if
  you are not a member of Econia Labs)
