### PR TITLE
ci(ECO-2221): Add movefmt, batchwise LaTex support for pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,6 +7,8 @@
 # cspell:word virtualenvs
 ---
 env:
+  APTOS_CLI_ACTION: 'aptos-labs/aptos-core/.github/actions/get-latest-cli'
+  APTOS_CLI_ACTION_COMMIT: 'e035f8635bc5407339c225197e30c0e9d10a70e2'
   POETRY_VERSION: '1.8.2'
   PYTHON_VERSION: '3.9'
 jobs:
@@ -17,7 +19,7 @@ jobs:
     - uses: 'actions/setup-python@v3'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
-    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@e035f8635bc5'
+    - uses: '${{ env.APTOS_CLI_ACTION }}@${{ env.APTOS_CLI_ACTION_COMMIT }}'
       with:
         destination_directory: '/usr/local/bin'
     - name: 'Install LaTeX lint dependencies'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -17,8 +17,8 @@ jobs:
     - uses: 'actions/setup-python@v3'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
-    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@\
-        e035f8635bc5407339c225197e30c0e9d10a70e2'
+    # yamllint disable-line rule:line-length
+    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@e035f8635bc5407339c225197e30c0e9d10a70e2'
       with:
         destination_directory: '/usr/local/bin'
     - name: 'Install LaTeX lint dependencies'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,8 +7,7 @@
 # cspell:word virtualenvs
 ---
 env:
-  APTOS_CLI_ACTION: 'aptos-labs/aptos-core/.github/actions/get-latest-cli'
-  APTOS_CLI_ACTION_COMMIT: 'e035f8635bc5407339c225197e30c0e9d10a70e2'
+  APTOS_CLI_ACTION_REF: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@e035f8635bc5407339c225197e30c0e9d10a70e2'
   POETRY_VERSION: '1.8.2'
   PYTHON_VERSION: '3.9'
 jobs:
@@ -19,7 +18,7 @@ jobs:
     - uses: 'actions/setup-python@v3'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
-    - uses: '${{ env.APTOS_CLI_ACTION }}@${{ env.APTOS_CLI_ACTION_COMMIT }}'
+    - uses: '${{ env.APTOS_CLI_ACTION_REF }}'
       with:
         destination_directory: '/usr/local/bin'
     - name: 'Install LaTeX lint dependencies'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -17,8 +17,7 @@ jobs:
     - uses: 'actions/setup-python@v3'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
-    - uses: |
-        aptos-labs/aptos-core/.github/actions/get-latest-cli@
+    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@\
         e035f8635bc5407339c225197e30c0e9d10a70e2'
       with:
         destination_directory: '/usr/local/bin'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -62,6 +62,7 @@ jobs:
         extra_args: '--all-files --config cfg/pre-commit-config.yaml --verbose'
 name: 'pre-commit'
 'on':
+  merge_group: null
   pull_request: null
   workflow_dispatch: null
 ...

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -17,6 +17,9 @@ jobs:
     - uses: 'actions/setup-python@v3'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
+    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@e035f8635bc5'
+      with:
+        destination_directory: '/usr/local/bin'
     - name: 'Install LaTeX lint dependencies'
       run: |
         sudo apt-get update

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
     # yamllint disable-line rule:line-length
-    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@e035f8635bc5407339c225197e30c0e9d10a70e2'
+    - uses: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@aptos-framework-v1.27.0'
       with:
         destination_directory: '/usr/local/bin'
     - name: 'Install LaTeX lint dependencies'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,6 +25,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y chktex lacheck texlive-base
+    - name: 'Update movefmt'
+      run: 'aptos update movefmt'
     - name: 'Cache Poetry Install'
       uses: 'actions/cache@v3'
       with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,6 +7,7 @@
 # cspell:word virtualenvs
 ---
 env:
+  MOVEFMT_VERSION: 'v1.0.7'
   POETRY_VERSION: '1.8.2'
   PYTHON_VERSION: '3.9'
 jobs:
@@ -26,7 +27,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y chktex lacheck texlive-base
     - name: 'Update movefmt'
-      run: 'aptos update movefmt'
+      run: 'aptos update movefmt --target-version "${{ env.MOVEFMT_VERSION }}"'
     - name: 'Cache Poetry Install'
       uses: 'actions/cache@v3'
       with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,7 +7,6 @@
 # cspell:word virtualenvs
 ---
 env:
-  APTOS_CLI_ACTION_REF: 'aptos-labs/aptos-core/.github/actions/get-latest-cli@e035f8635bc5407339c225197e30c0e9d10a70e2'
   POETRY_VERSION: '1.8.2'
   PYTHON_VERSION: '3.9'
 jobs:
@@ -18,7 +17,9 @@ jobs:
     - uses: 'actions/setup-python@v3'
       with:
         python-version: '${{ env.PYTHON_VERSION }}'
-    - uses: '${{ env.APTOS_CLI_ACTION_REF }}'
+    - uses: |
+        aptos-labs/aptos-core/.github/actions/get-latest-cli@
+        e035f8635bc5407339c225197e30c0e9d10a70e2'
       with:
         destination_directory: '/usr/local/bin'
     - name: 'Install LaTeX lint dependencies'

--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -7,6 +7,7 @@ collateralized
 cpamm
 econia
 forall
+movefmt
 octas
 precommit
 significand

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -63,9 +63,7 @@ repos:
     - 'tex'
   -
     entry: |
-      sh -c '
-        aptos move fmt --package-path $(dirname "$1")
-      '
+      sh -c 'aptos move fmt --package-path $(dirname "$1")'
     files: 'Move\.toml$'
     id: 'movefmt'
     language: 'system'

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -62,9 +62,17 @@ repos:
     types:
     - 'tex'
   -
+    # Loop over each Move.toml file passed per filename batch, and format the
+    # corresponding package directory, exiting with error if any format fails.
+    # yamllint disable rule:indentation
     entry: |
-      sh -c 'aptos move fmt --package-path $(dirname "$1")'
-    files: 'Move\.toml$'
+      sh -c '
+        for f in "$@"; do
+          aptos move fmt --package-path "$(dirname "$f")" || exit 1
+        done
+      '
+    # yamllint enable rule:indentation
+    files: 'Move.toml'
     id: 'movefmt'
     language: 'system'
     name: 'movefmt'

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -30,31 +30,51 @@ repos:
   repo: 'https://github.com/jonasbb/pre-commit-latex-hooks'
   rev: 'v1.4.3'
 - hooks:
-  - entry: 'chktex'
+  # Loop through each tex file passed by pre-commit (files are passed in
+  # batches). Run chktex on each file. If any check fails, exit with error.
+  # yamllint disable rule:indentation
+  - entry: |
+      sh -c '
+        for f in "$@"; do
+          chktex "$f" || exit 1
+        done
+      '
+    # yamllint enable rule:indentation
     id: 'chktex'
     language: 'system'
     name: 'chktex'
     types:
     - 'tex'
+  # Loop through each tex file passed by pre-commit (files are passed in
+  # batches). Run lacheck on each file. If any check fails, exit with error.
+  #
   # Before running lacheck on an individual file, change the working directory
   # to the directory containing the file, and then run lacheck on the file
   # directly so that lacheck can incorporate relative references to imports.
+  #
   # Show all warnings and fail if any are found, but ignore:
   # - Lines starting with ** (input file notifications).
-  # - Warnings about @ in LaTeX macro names.
-  # See https://tex.stackexchange.com/a/155451
+  # - Warnings about @ in macros per https://tex.stackexchange.com/a/155451.
+  #
   # yamllint disable rule:indentation
   - entry: |
       sh -c '
-        cd $(dirname "$1") && \
-        output=$(lacheck $(basename "$1") | \
-          grep -v "^\*\*" | \
-          grep -v "Do not use @ in LaTeX macro names" || true) && \
-        if [ -n "$output" ]; then
-          echo "$output"
-          exit 1
-        fi
-      ' --
+        # Exit on first error.
+        set -e
+        # Loop through all files passed by pre-commit.
+        for f in "$@"; do
+          cd "$(dirname "$f")" && \
+          output=$(lacheck "$(basename "$f")" | \
+            grep -v "^\*\*" | \
+            grep -v "Do not use @ in LaTeX macro names" || true) && \
+          if [ -n "$output" ]; then
+            echo "$output"
+            exit 1
+          fi
+          # Return to original directory for next file.
+          cd - > /dev/null
+        done
+      '
     # yamllint enable rule:indentation
     id: 'lacheck'
     language: 'system'

--- a/cfg/pre-commit-config.yaml
+++ b/cfg/pre-commit-config.yaml
@@ -61,6 +61,15 @@ repos:
     name: 'lacheck'
     types:
     - 'tex'
+  -
+    entry: |
+      sh -c '
+        aptos move fmt --package-path $(dirname "$1")
+      '
+    files: 'Move\.toml$'
+    id: 'movefmt'
+    language: 'system'
+    name: 'movefmt'
   repo: 'local'
 -
   hooks:


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Add a movefmt step to pre-commit, and update LaTeX to be batchwise per #73 (which I accidentally merged into here early)

# Testing

CI should fail until #72 merges, then pass
