### PR TITLE
build(ECO-2897): Use Aptos Framework mirror for faster clones

### DIFF
--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -2,9 +2,9 @@
 econia = "_"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dev-addresses]
 econia = "0xc0de"

--- a/src/move/research/red-black-map/variants/a/Move.toml
+++ b/src/move/research/red-black-map/variants/a/Move.toml
@@ -2,9 +2,9 @@
 red_black_map = '_'
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dev-addresses]
 red_black_map = '0xabc'

--- a/src/move/research/uniswap-v3-book-milestone-1/Move.toml
+++ b/src/move/research/uniswap-v3-book-milestone-1/Move.toml
@@ -2,9 +2,9 @@
 research = "0xace"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [package]
 authors = []

--- a/src/move/research/uniswap-v3-whitepaper/Move.toml
+++ b/src/move/research/uniswap-v3-whitepaper/Move.toml
@@ -2,9 +2,9 @@
 research = "0xace"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [package]
 authors = []


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Use the mirror of the Aptos Framework for faster clones during CI test runs

# Testing

- [x] CI passing
- [x] #76 

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
