### PR TITLE
ci(ECO-2898): Update move tests action to properly exit

### DIFF
--- a/.github/workflows/move-tests.yaml
+++ b/.github/workflows/move-tests.yaml
@@ -13,10 +13,15 @@ jobs:
       # any failure.
       # yamllint disable-line rule:indentation
       run: |
-        find . -name "Move.toml" -exec sh -c -e '
+        status=0
+        find . -name "Move.toml" -exec sh -c '
           echo "Testing package in directory: $(dirname "{}")"
-          aptos move test --dev --package-dir "$(dirname "{}")" || exit 1
-        ' \;
+          if ! aptos move test --dev --package-dir "$(dirname "{}")"; then
+            echo "Test failed in directory: $(dirname "{}")"
+            exit 1
+          fi
+        ' \; || status=$?
+        exit $status
 # yamllint enable-line rule:indentation
 name: 'move-tests'
 'on':

--- a/.github/workflows/move-tests.yaml
+++ b/.github/workflows/move-tests.yaml
@@ -13,15 +13,15 @@ jobs:
       # any failure.
       # yamllint disable-line rule:indentation
       run: |
-        status=0
-        find . -name "Move.toml" -exec sh -c '
-          echo "Testing package in directory: $(dirname "{}")"
-          if ! aptos move test --dev --package-dir "$(dirname "{}")"; then
-            echo "Test failed in directory: $(dirname "{}")"
+        set -e
+        find . -name "Move.toml" | while read -r toml; do
+          dir=$(dirname "$toml")
+          echo "Testing package in directory: $dir"
+          if ! aptos move test --dev --package-dir "$dir"; then
+            echo "Test failed in directory: $dir"
             exit 1
           fi
-        ' \; || status=$?
-        exit $status
+        done
 # yamllint enable-line rule:indentation
 name: 'move-tests'
 'on':

--- a/.github/workflows/move-tests.yaml
+++ b/.github/workflows/move-tests.yaml
@@ -9,10 +9,11 @@ jobs:
       with:
         destination_directory: '/usr/local/bin'
     - name: 'Find and test Move packages'
+      # Find all Move packages and run tests in each directory, exiting on
+      # any failure.
       # yamllint disable-line rule:indentation
       run: |
-        # Find all Move.toml files and run tests in their directories
-        find . -name "Move.toml" -exec sh -c '
+        find . -name "Move.toml" -exec sh -c -e '
           echo "Testing package in directory: $(dirname "{}")"
           aptos move test --dev --package-dir "$(dirname "{}")" || exit 1
         ' \;

--- a/src/move/research/fee/sources/fee.move
+++ b/src/move/research/fee/sources/fee.move
@@ -35,7 +35,7 @@ module fee::fee {
         assert!(fee == 300);
         assert!(volume == 20_000);
         (fee, volume) = pre_match(20_300, 0);
-        assert!(fee == 0);
+        assert!(fee == 1);
         assert!(volume == 20_300);
     }
 }

--- a/src/move/research/fee/sources/fee.move
+++ b/src/move/research/fee/sources/fee.move
@@ -35,7 +35,7 @@ module fee::fee {
         assert!(fee == 300);
         assert!(volume == 20_000);
         (fee, volume) = pre_match(20_300, 0);
-        assert!(fee == 1);
+        assert!(fee == 0);
         assert!(volume == 20_300);
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

While developing #75 I realized that the action does not properly exit when move tests fail. This fixes it to properly exit with failed check status when a test fails

# Testing

- [x] Proper pass when all tests pass per pre-merge checks
- [x] Proper fail when a test fails https://github.com/econia-labs/econia-x/actions/runs/13426174835/job/37509440068?pr=76 per 51f7861

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
