### PR TITLE
fix(ECO-2899): Use official calls/rev for core package

### DIFF
--- a/src/move/econia/Move.toml
+++ b/src/move/econia/Move.toml
@@ -1,11 +1,9 @@
-# cspell:words lightmark
-
 [addresses]
 econia = "_"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"
-rev = "lightmark/fa_migrate_optimized"
+rev = "mainnet"
 subdir = "aptos-move/framework/aptos-framework"
 
 [dev-addresses]

--- a/src/move/econia/sources/core.move
+++ b/src/move/econia/sources/core.move
@@ -733,8 +733,8 @@ module econia::core {
     #[test_only]
     public fun ensure_module_initialized_for_test() {
         let feature = features::get_coin_to_fungible_asset_migration_feature();
-        features::change_feature_flags(&get_signer(@std), vector[feature], vector[]);
-        aptos_coin::ensure_initialized_with_fa_metadata_for_test();
+        features::change_feature_flags_for_testing(&get_signer(@std), vector[feature], vector[]);
+        aptos_coin::ensure_initialized_with_apt_fa_metadata_for_test();
         if (!exists<Registry>(@econia)) init_module(&get_signer(@econia));
     }
 
@@ -752,9 +752,9 @@ module econia::core {
 
     #[test_only]
     public fun mint_fa_apt_to_market_registrant() {
-        aptos_coin::mint_fa_to_primary_fungible_store_for_test(
+        primary_fungible_store::deposit(
             MARKET_REGISTRANT_FOR_TEST,
-            GENESIS_MARKET_REGISTRATION_FEE
+            aptos_coin::mint_apt_fa_for_test(GENESIS_MARKET_REGISTRATION_FEE)
         );
     }
 

--- a/src/move/econia/sources/test_assets.move
+++ b/src/move/econia/sources/test_assets.move
@@ -36,7 +36,7 @@ module econia::test_assets {
     public fun ensure_assets_initialized() {
         if (exists<TestAssetsMetadata>(@econia)) return;
         let framework = account::create_signer_for_test(@std);
-        features::change_feature_flags(
+        features::change_feature_flags_for_testing(
             &framework, vector[features::get_auids()], vector[]
         );
         move_to(


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

During #76 I noticed that the tests for the core package were failing. So update the inner calls to use the `mainnet` APIs and revision, rather than the experimental revision that was used during prior design

# Testing

CI

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
