### PR TITLE
ci(ECO-2996): Use common code owners action

### DIFF
--- a/.github/workflows/codeowners.yaml
+++ b/.github/workflows/codeowners.yaml
@@ -1,23 +1,14 @@
-# cspell:word archetypically
-# cspell:word mszostok
-# cspell:word notowned
 ---
 jobs:
-  codeowners:
+  pr-size:
+    name: 'Code owners'
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: 'actions/checkout@v4'
-    - uses: 'mszostok/codeowners-validator@v0.7.4'
+    - uses: 'econia-labs/common/.github/actions/codeowners@main'
       with:
-        experimental_checks: 'avoid-shadowing,notowned'
         github_access_token: '${{ secrets.CODEOWNERS_VALIDATOR_GITHUB_TOKEN }}'
-    - uses: 'Archetypically/format-codeowners@v1'
-      with:
-        file-path: '.github/CODEOWNERS'
-        remove-empty-lines: 'true'
-name: 'Verify codeowners'
+name: 'Code owners'
 'on':
   merge_group: null
   pull_request: null
-  workflow_dispatch: null
 ...


### PR DESCRIPTION

# Description

Use the abstracted code owners check introduced by
https://github.com/econia-labs/common/pull/25

# Testing

CI

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)