### PR TITLE
docs(ECO-2905): Add custom AMM swap buy derivations, diagram

### DIFF
--- a/research/amm/README.md
+++ b/research/amm/README.md
@@ -7,7 +7,7 @@ relies on a LaTeX document which can be viewed easily using the
 [LaTeX Workshop extension for VS Code], or compiled from source via:
 
 ```sh
-latexmk -pdf amm.tex
+latexmk -pdf -silent
 ```
 
 [latex workshop extension for vs code]: https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop

--- a/research/amm/amm.tex
+++ b/research/amm/amm.tex
@@ -162,11 +162,11 @@ respectively given in terms of $b_i$, $q_i$, and $q_{in}$ in Equations%
 \end{equation}
 
 \begin{equation}\label{eqn:swap-buy-base-out-solved}
-	b_{out} (b_i, q_i, b_{in}) = \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
+	b_{out} (b_i, q_i, b_{in}) = \frac{b_i \cdot q_{in}}{q_i + q_{in}}
 \end{equation}
 
 \begin{equation}\label{eqn:swap-buy-execution-price-solved}
-	p_e (b_i, q_i, q_{in}) =
+	p_e (b_i, q_i, q_{in}) = \frac{q_i + q_{in}}{b_i}
 \end{equation}
 
 \section{Derivations}\label{sec:derivations}
@@ -239,9 +239,10 @@ Substitute Equation~\ref{eqn:swap-sell-quote-out-solved}.
 
 Rearrange.
 
-\begin{equation}
-	p_e (b_i, q_i, b_{in}) = \frac{q_i}{b_i + b_{in}} \nonumber
-\end{equation}
+\begin{align}
+	p_e &= \frac{q_i \cdot b_{in}}{b_{in} \cdot (b_i + b_{in})} \nonumber \\
+	p_e &= \frac{q_i}{b_i + b_{in}} \nonumber \\
+\end{align}
 
 \subsection{Swap buy derivations}\label{ssec:swap-buy-derivations}
 
@@ -290,6 +291,28 @@ Rearrange.
   b_i \cdot q_i + b_i \cdot q_{in} - b_i \cdot q_i \nonumber \\
   (q_i + q_{in}) \cdot b_{out} &= b_i \cdot q_{in} \nonumber \\
   b_{out} &= \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
+\end{align}
+
+\subsubsection{Equation~\ref{eqn:swap-buy-execution-price-solved} derivation}%
+\label{sssec:equation-eqn-swap-buy-execution-price-solved-derivation}
+
+Consider Equation~\ref{eqn:swap-buy-execution-price}.
+
+\begin{equation}
+  p_e = \frac{q_{in}}{b_{out}} \nonumber
+\end{equation}
+
+Substitute equation Equation~\ref{eqn:swap-buy-base-out-solved}.
+
+\begin{equation}
+  p_e = \frac{q_{in}}{\left(\dfrac{b_i \cdot q_{in}}{q_i + q_{in}}\right)} \nonumber
+\end{equation}
+
+Rearrange.
+
+\begin{align}
+  p_e &= \frac{q_{in} \cdot (q_i + q_{in})}{b_i \cdot q_{in}} \nonumber \\
+  p_e &= \frac{q_i + q_{in}}{b_i} \nonumber \\
 \end{align}
 
 \end{document} % chktex 17

--- a/research/amm/amm.tex
+++ b/research/amm/amm.tex
@@ -212,14 +212,14 @@ Substitute Equation~\ref{eqn:swap-sell-quote-final-solved}.
 Rearrange.
 
 \begin{align}
-	q_{out} & = q_i - \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber       \\
-	(b_i + b_{in}) \cdot q_{out} &= q_i \cdot (b_i + b_{in}) - b_i \cdot q_i \nonumber \\
-	(b_i + b_{in}) \cdot q_{out} &=
-  q_i \cdot b_i + q_i \cdot b_{in} - b_i \cdot q_i \nonumber \\
-	(b_i + b_{in}) \cdot q_{out} &=
-  b_i \cdot q_i + b_{in} \cdot q_i - b_i \cdot q_i \nonumber \\
-	(b_i + b_{in}) \cdot q_{out} &= b_{in} \cdot q_i \nonumber \\
-	q_{out} & = \frac{b_{in} \cdot q_i}{b_i + b_{in}} \nonumber \\
+	q_{out}                      & = q_i - \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} & = q_i \cdot (b_i + b_{in}) - b_i \cdot q_i \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} & =
+	q_i \cdot b_i + q_i \cdot b_{in} - b_i \cdot q_i \nonumber                          \\
+	(b_i + b_{in}) \cdot q_{out} & =
+	b_i \cdot q_i + b_{in} \cdot q_i - b_i \cdot q_i \nonumber                          \\
+	(b_i + b_{in}) \cdot q_{out} & = b_{in} \cdot q_i \nonumber                         \\
+	q_{out}                      & = \frac{b_{in} \cdot q_i}{b_i + b_{in}} \nonumber    \\
 \end{align}
 
 \subsubsection{Equation~\ref{eqn:swap-sell-execution-price-solved} derivation}%
@@ -240,8 +240,8 @@ Substitute Equation~\ref{eqn:swap-sell-quote-out-solved}.
 Rearrange.
 
 \begin{align}
-	p_e &= \frac{q_i \cdot b_{in}}{b_{in} \cdot (b_i + b_{in})} \nonumber \\
-	p_e &= \frac{q_i}{b_i + b_{in}} \nonumber \\
+	p_e & = \frac{q_i \cdot b_{in}}{b_{in} \cdot (b_i + b_{in})} \nonumber \\
+	p_e & = \frac{q_i}{b_i + b_{in}} \nonumber                             \\
 \end{align}
 
 \subsection{Swap buy derivations}\label{ssec:swap-buy-derivations}
@@ -258,13 +258,13 @@ Consider Equation~\ref{eqn:swap-constant-product}.
 Substitute Equation~\ref{eqn:swap-buy-quote-final}.
 
 \begin{equation}
-  b_i \cdot q_i = b_f \cdot (q_i + q_{in}) \nonumber
+	b_i \cdot q_i = b_f \cdot (q_i + q_{in}) \nonumber
 \end{equation}
 
 Rearrange.
 
 \begin{equation}
-  b_f = \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber
+	b_f = \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber
 \end{equation}
 
 \subsubsection{Equation~\ref{eqn:swap-buy-base-out-solved} derivation}%
@@ -273,24 +273,24 @@ Rearrange.
 Consider equation Equation~\ref{eqn:swap-buy-base-final}.
 
 \begin{equation}
-  b_f = b_i - b_{out} \nonumber
+	b_f = b_i - b_{out} \nonumber
 \end{equation}
 
 Substitute equation Equation~\ref{eqn:swap-buy-base-final-solved}.
 
 \begin{equation}
-  \frac{b_i \cdot q_i}{q_i + q_{in}} = b_i - b_{out} \nonumber
+	\frac{b_i \cdot q_i}{q_i + q_{in}} = b_i - b_{out} \nonumber
 \end{equation}
 
 Rearrange.
 
 \begin{align}
-  b_{out} &= b_i - \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber \\
-  (q_i + q_{in}) \cdot b_{out} &= b_i \cdot (q_i + q_{in})- b_i \cdot q_i \nonumber \\
-  (q_i + q_{in}) \cdot b_{out} &=
-  b_i \cdot q_i + b_i \cdot q_{in} - b_i \cdot q_i \nonumber \\
-  (q_i + q_{in}) \cdot b_{out} &= b_i \cdot q_{in} \nonumber \\
-  b_{out} &= \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
+	b_{out}                      & = b_i - \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber \\
+	(q_i + q_{in}) \cdot b_{out} & = b_i \cdot (q_i + q_{in})- b_i \cdot q_i \nonumber  \\
+	(q_i + q_{in}) \cdot b_{out} & =
+	b_i \cdot q_i + b_i \cdot q_{in} - b_i \cdot q_i \nonumber                          \\
+	(q_i + q_{in}) \cdot b_{out} & = b_i \cdot q_{in} \nonumber                         \\
+	b_{out}                      & = \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
 \end{align}
 
 \subsubsection{Equation~\ref{eqn:swap-buy-execution-price-solved} derivation}%
@@ -299,20 +299,20 @@ Rearrange.
 Consider Equation~\ref{eqn:swap-buy-execution-price}.
 
 \begin{equation}
-  p_e = \frac{q_{in}}{b_{out}} \nonumber
+	p_e = \frac{q_{in}}{b_{out}} \nonumber
 \end{equation}
 
 Substitute equation Equation~\ref{eqn:swap-buy-base-out-solved}.
 
 \begin{equation}
-  p_e = \frac{q_{in}}{\left(\dfrac{b_i \cdot q_{in}}{q_i + q_{in}}\right)} \nonumber
+	p_e = \frac{q_{in}}{\left(\dfrac{b_i \cdot q_{in}}{q_i + q_{in}}\right)} \nonumber
 \end{equation}
 
 Rearrange.
 
 \begin{align}
-  p_e &= \frac{q_{in} \cdot (q_i + q_{in})}{b_i \cdot q_{in}} \nonumber \\
-  p_e &= \frac{q_i + q_{in}}{b_i} \nonumber \\
+	p_e & = \frac{q_{in} \cdot (q_i + q_{in})}{b_i \cdot q_{in}} \nonumber \\
+	p_e & = \frac{q_i + q_{in}}{b_i} \nonumber                             \\
 \end{align}
 
 \end{document} % chktex 17

--- a/research/amm/amm.tex
+++ b/research/amm/amm.tex
@@ -213,11 +213,13 @@ Rearrange.
 
 \begin{align}
 	q_{out} & = q_i - \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber       \\
-	q_{out} & = q_i \cdot \frac{b_i + b_{in}}{b_i + b_{in}} -
-	\frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber                         \\
-	q_{out} & = \frac{b_i \cdot q_i + b_{in} \cdot q_i }{b_i + b_{in}} -
-	\frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber                         \\
-	q_{out} & = \frac{b_{in} \cdot q_i }{b_i + b_{in}} \nonumber
+	(b_i + b_{in}) \cdot q_{out} &= q_i \cdot (b_i + b_{in}) - b_i \cdot q_i \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} &=
+  q_i \cdot b_i + q_i \cdot b_{in} - b_i \cdot q_i \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} &=
+  b_i \cdot q_i + b_{in} \cdot q_i - b_i \cdot q_i \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} &= b_{in} \cdot q_i \nonumber \\
+	q_{out} & = \frac{b_{in} \cdot q_i}{b_i + b_{in}} \nonumber \\
 \end{align}
 
 \subsubsection{Equation~\ref{eqn:swap-sell-execution-price-solved} derivation}%
@@ -273,7 +275,7 @@ Consider equation Equation~\ref{eqn:swap-buy-base-final}.
   b_f = b_i - b_{out} \nonumber
 \end{equation}
 
-Subsititue equation Equation~\ref{eqn:swap-buy-base-final-solved}.
+Substitute equation Equation~\ref{eqn:swap-buy-base-final-solved}.
 
 \begin{equation}
   \frac{b_i \cdot q_i}{q_i + q_{in}} = b_i - b_{out} \nonumber
@@ -283,10 +285,10 @@ Rearrange.
 
 \begin{align}
   b_{out} &= b_i - \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber \\
-  b_{out} \cdot (q_i + q_{in}) &= b_i \cdot (q_i + q_{in})- b_i \cdot q_i \nonumber \\
-  b_{out} \cdot (q_i + q_{in}) &=
+  (q_i + q_{in}) \cdot b_{out} &= b_i \cdot (q_i + q_{in})- b_i \cdot q_i \nonumber \\
+  (q_i + q_{in}) \cdot b_{out} &=
   b_i \cdot q_i + b_i \cdot q_{in} - b_i \cdot q_i \nonumber \\
-  b_{out} \cdot (q_i + q_{in}) &= b_i \cdot q_{in} \nonumber \\
+  (q_i + q_{in}) \cdot b_{out} &= b_i \cdot q_{in} \nonumber \\
   b_{out} &= \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
 \end{align}
 

--- a/research/amm/amm.tex
+++ b/research/amm/amm.tex
@@ -92,7 +92,7 @@ for quote output amount $q_{out}$.
 	\caption{Swap sell}\label{fig:swap-sell}
 \end{figure}
 
-The final base and quote amounts are respectively given in
+The final base and quote reserves are respectively given in
 Equations~\ref{eqn:swap-sell-base-final} and~\ref{eqn:swap-sell-quote-final}, and the
 swap execution price $p_e$ is given in Equation~\ref{eqn:swap-sell-execution-price}.
 
@@ -136,7 +136,7 @@ to buy base output amount $b_{out}$.
 	\caption{Swap buy}\label{fig:swap-buy}
 \end{figure}
 
-The final base and quote amounts are respectively given in
+The final base and quote reserves are respectively given in
 Equations~\ref{eqn:swap-buy-base-final} and~\ref{eqn:swap-buy-quote-final}, and the
 swap execution price $p_e$ is given in Equation~\ref{eqn:swap-buy-execution-price}.
 
@@ -150,6 +150,23 @@ swap execution price $p_e$ is given in Equation~\ref{eqn:swap-buy-execution-pric
 
 \begin{equation}\label{eqn:swap-buy-execution-price}
 	p_e = \frac{q_{in}}{b_{out}}
+\end{equation}
+
+As derived in Section~\ref{ssec:swap-buy-derivations}, $b_f$, $b_{out}$, and $p_e$ are
+respectively given in terms of $b_i$, $q_i$, and $q_{in}$ in Equations%
+~\ref{eqn:swap-buy-base-final-solved},~\ref{eqn:swap-buy-base-out-solved}, and%
+~\ref{eqn:swap-buy-execution-price-solved}.
+
+\begin{equation}\label{eqn:swap-buy-base-final-solved}
+	b_f(b_i, q_i, b_{in}) = \frac{b_i \cdot q_i}{q_i + q_{in}}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-buy-base-out-solved}
+	b_{out} (b_i, q_i, b_{in}) = \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
+\end{equation}
+
+\begin{equation}\label{eqn:swap-buy-execution-price-solved}
+	p_e (b_i, q_i, q_{in}) =
 \end{equation}
 
 \section{Derivations}\label{sec:derivations}
@@ -223,5 +240,54 @@ Rearrange.
 \begin{equation}
 	p_e (b_i, q_i, b_{in}) = \frac{q_i}{b_i + b_{in}} \nonumber
 \end{equation}
+
+\subsection{Swap buy derivations}\label{ssec:swap-buy-derivations}
+
+\subsubsection{Equation~\ref{eqn:swap-buy-base-final-solved} derivation}%
+\label{sssec:equation-eqn-swap-buy-base-final-solved-derivation}
+
+Consider Equation~\ref{eqn:swap-constant-product}.
+
+\begin{equation}
+	b_i \cdot q_i = b_f \cdot q_f \nonumber
+\end{equation}
+
+Substitute Equation~\ref{eqn:swap-buy-quote-final}.
+
+\begin{equation}
+  b_i \cdot q_i = b_f \cdot (q_i + q_{in}) \nonumber
+\end{equation}
+
+Rearrange.
+
+\begin{equation}
+  b_f = \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber
+\end{equation}
+
+\subsubsection{Equation~\ref{eqn:swap-buy-base-out-solved} derivation}%
+\label{sssec:equation-eqn-swap-buy-base-out-solved-derivation}
+
+Consider equation Equation~\ref{eqn:swap-buy-base-final}.
+
+\begin{equation}
+  b_f = b_i - b_{out} \nonumber
+\end{equation}
+
+Subsititue equation Equation~\ref{eqn:swap-buy-base-final-solved}.
+
+\begin{equation}
+  \frac{b_i \cdot q_i}{q_i + q_{in}} = b_i - b_{out} \nonumber
+\end{equation}
+
+Rearrange.
+
+\begin{align}
+  b_{out} &= b_i - \frac{b_i \cdot q_i}{q_i + q_{in}} \nonumber \\
+  b_{out} \cdot (q_i + q_{in}) &= b_i \cdot (q_i + q_{in})- b_i \cdot q_i \nonumber \\
+  b_{out} \cdot (q_i + q_{in}) &=
+  b_i \cdot q_i + b_i \cdot q_{in} - b_i \cdot q_i \nonumber \\
+  b_{out} \cdot (q_i + q_{in}) &= b_i \cdot q_{in} \nonumber \\
+  b_{out} &= \frac{b_i \cdot q_{in}}{q_i + q_{in}} \nonumber
+\end{align}
 
 \end{document} % chktex 17

--- a/research/amm/amm.tex
+++ b/research/amm/amm.tex
@@ -125,6 +125,33 @@ respectively given in terms of $b_i$, $q_i$, and $b_{in}$ in Equations%
 	p_e (b_i, q_i, b_{in}) = \frac{q_i}{b_i + b_{in}}
 \end{equation}
 
+\subsection{Swap buy}\label{ssec:swap-buy}
+
+Figure~\ref{fig:swap-buy} illustrates a swap where quote input amount $q_{in}$ is used
+to buy base output amount $b_{out}$.
+
+\begin{figure}[!htb]
+	\centering
+	\input{figures/swap-buy.tex}
+	\caption{Swap buy}\label{fig:swap-buy}
+\end{figure}
+
+The final base and quote amounts are respectively given in
+Equations~\ref{eqn:swap-buy-base-final} and~\ref{eqn:swap-buy-quote-final}, and the
+swap execution price $p_e$ is given in Equation~\ref{eqn:swap-buy-execution-price}.
+
+\begin{equation}\label{eqn:swap-buy-base-final}
+	b_f = b_i - b_{out}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-buy-quote-final}
+	q_f = q_i + q_{in}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-buy-execution-price}
+	p_e = \frac{q_{in}}{b_{out}}
+\end{equation}
+
 \section{Derivations}\label{sec:derivations}
 
 \subsection{Swap sell derivations}\label{ssec:swap-sell-derivations}

--- a/research/amm/amm.tex
+++ b/research/amm/amm.tex
@@ -81,50 +81,6 @@ Equation~\ref{eqn:swap-constant-product}.
 	b_i \cdot q_i = b_f \cdot q_f
 \end{equation}
 
-\subsection{Swap sell}\label{ssec:swap-sell}
-
-Figure~\ref{fig:swap-sell} illustrates a swap where base input amount $b_{in}$ is sold
-for quote output amount $q_{out}$.
-
-\begin{figure}[!htb]
-	\centering
-	\input{figures/swap-sell.tex}
-	\caption{Swap sell}\label{fig:swap-sell}
-\end{figure}
-
-The final base and quote reserves are respectively given in
-Equations~\ref{eqn:swap-sell-base-final} and~\ref{eqn:swap-sell-quote-final}, and the
-swap execution price $p_e$ is given in Equation~\ref{eqn:swap-sell-execution-price}.
-
-\begin{equation}\label{eqn:swap-sell-base-final}
-	b_f = b_i + b_{in}
-\end{equation}
-
-\begin{equation}\label{eqn:swap-sell-quote-final}
-	q_f = q_i - q_{out}
-\end{equation}
-
-\begin{equation}\label{eqn:swap-sell-execution-price}
-	p_e = \frac{q_{out}}{b_{in}}
-\end{equation}
-
-As derived in Section~\ref{ssec:swap-sell-derivations}, $q_f$, $q_{out}$, and $p_e$ are
-respectively given in terms of $b_i$, $q_i$, and $b_{in}$ in Equations%
-~\ref{eqn:swap-sell-quote-final-solved},~\ref{eqn:swap-sell-quote-out-solved}, and%
-~\ref{eqn:swap-sell-execution-price-solved}.
-
-\begin{equation}\label{eqn:swap-sell-quote-final-solved}
-	q_f(b_i, q_i, b_{in}) = \frac{b_i \cdot q_i}{b_i + b_{in}}
-\end{equation}
-
-\begin{equation}\label{eqn:swap-sell-quote-out-solved}
-	q_{out} (b_i, q_i, b_{in}) = \frac{b_{in} \cdot q_i}{b_i + b_{in}}
-\end{equation}
-
-\begin{equation}\label{eqn:swap-sell-execution-price-solved}
-	p_e (b_i, q_i, b_{in}) = \frac{q_i}{b_i + b_{in}}
-\end{equation}
-
 \subsection{Swap buy}\label{ssec:swap-buy}
 
 Figure~\ref{fig:swap-buy} illustrates a swap where quote input amount $q_{in}$ is used
@@ -169,80 +125,51 @@ respectively given in terms of $b_i$, $q_i$, and $q_{in}$ in Equations%
 	p_e (b_i, q_i, q_{in}) = \frac{q_i + q_{in}}{b_i}
 \end{equation}
 
+\subsection{Swap sell}\label{ssec:swap-sell}
+
+Figure~\ref{fig:swap-sell} illustrates a swap where base input amount $b_{in}$ is sold
+for quote output amount $q_{out}$.
+
+\begin{figure}[!htb]
+	\centering
+	\input{figures/swap-sell.tex}
+	\caption{Swap sell}\label{fig:swap-sell}
+\end{figure}
+
+The final base and quote reserves are respectively given in
+Equations~\ref{eqn:swap-sell-base-final} and~\ref{eqn:swap-sell-quote-final}, and the
+swap execution price $p_e$ is given in Equation~\ref{eqn:swap-sell-execution-price}.
+
+\begin{equation}\label{eqn:swap-sell-base-final}
+	b_f = b_i + b_{in}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-sell-quote-final}
+	q_f = q_i - q_{out}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-sell-execution-price}
+	p_e = \frac{q_{out}}{b_{in}}
+\end{equation}
+
+As derived in Section~\ref{ssec:swap-sell-derivations}, $q_f$, $q_{out}$, and $p_e$ are
+respectively given in terms of $b_i$, $q_i$, and $b_{in}$ in Equations%
+~\ref{eqn:swap-sell-quote-final-solved},~\ref{eqn:swap-sell-quote-out-solved}, and%
+~\ref{eqn:swap-sell-execution-price-solved}.
+
+\begin{equation}\label{eqn:swap-sell-quote-final-solved}
+	q_f(b_i, q_i, b_{in}) = \frac{b_i \cdot q_i}{b_i + b_{in}}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-sell-quote-out-solved}
+	q_{out} (b_i, q_i, b_{in}) = \frac{b_{in} \cdot q_i}{b_i + b_{in}}
+\end{equation}
+
+\begin{equation}\label{eqn:swap-sell-execution-price-solved}
+	p_e (b_i, q_i, b_{in}) = \frac{q_i}{b_i + b_{in}}
+\end{equation}
+
 \section{Derivations}\label{sec:derivations}
-
-\subsection{Swap sell derivations}\label{ssec:swap-sell-derivations}
-
-\subsubsection{Equation~\ref{eqn:swap-sell-quote-final-solved} derivation}%
-\label{sssec:equation-eqn-swap-sell-quote-final-solved-derivation}
-
-Consider Equation~\ref{eqn:swap-constant-product}.
-
-\begin{equation}
-	b_i \cdot q_i = b_f \cdot q_f \nonumber
-\end{equation}
-
-Substitute Equation~\ref{eqn:swap-sell-base-final}.
-
-\begin{equation}
-	b_i \cdot q_i = (b_i + b_{in}) \cdot q_f \nonumber
-\end{equation}
-
-Rearrange.
-
-\begin{equation}
-	q_f = \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber
-\end{equation}
-
-\subsubsection{Equation~\ref{eqn:swap-sell-quote-out-solved} derivation}%
-\label{sssec:equation-eqn-swap-sell-quote-out-solved-derivation}
-
-Consider Equation~\ref{eqn:swap-sell-quote-final}.
-
-\begin{equation}
-	q_f = q_i - q_{out} \nonumber
-\end{equation}
-
-Substitute Equation~\ref{eqn:swap-sell-quote-final-solved}.
-
-\begin{equation}
-	\frac{b_i \cdot q_i}{b_i + b_{in}}= q_i - q_{out} \nonumber
-\end{equation}
-
-Rearrange.
-
-\begin{align}
-	q_{out}                      & = q_i - \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber \\
-	(b_i + b_{in}) \cdot q_{out} & = q_i \cdot (b_i + b_{in}) - b_i \cdot q_i \nonumber \\
-	(b_i + b_{in}) \cdot q_{out} & =
-	q_i \cdot b_i + q_i \cdot b_{in} - b_i \cdot q_i \nonumber                          \\
-	(b_i + b_{in}) \cdot q_{out} & =
-	b_i \cdot q_i + b_{in} \cdot q_i - b_i \cdot q_i \nonumber                          \\
-	(b_i + b_{in}) \cdot q_{out} & = b_{in} \cdot q_i \nonumber                         \\
-	q_{out}                      & = \frac{b_{in} \cdot q_i}{b_i + b_{in}} \nonumber    \\
-\end{align}
-
-\subsubsection{Equation~\ref{eqn:swap-sell-execution-price-solved} derivation}%
-\label{sssec:equation-eqn-swap-sell-execution-price-solved-derivation}
-
-Consider Equation~\ref{eqn:swap-sell-execution-price}.
-
-\begin{equation}
-	p_e = \frac{q_{out}}{b_{in}} \nonumber
-\end{equation}
-
-Substitute Equation~\ref{eqn:swap-sell-quote-out-solved}.
-
-\begin{equation}
-	p_e = \dfrac{\left(\dfrac{q_i \cdot b_{in}}{b_i + b_{in}}\right)}{b_{in}} \nonumber
-\end{equation}
-
-Rearrange.
-
-\begin{align}
-	p_e & = \frac{q_i \cdot b_{in}}{b_{in} \cdot (b_i + b_{in})} \nonumber \\
-	p_e & = \frac{q_i}{b_i + b_{in}} \nonumber                             \\
-\end{align}
 
 \subsection{Swap buy derivations}\label{ssec:swap-buy-derivations}
 
@@ -312,7 +239,80 @@ Rearrange.
 
 \begin{align}
 	p_e & = \frac{q_{in} \cdot (q_i + q_{in})}{b_i \cdot q_{in}} \nonumber \\
-	p_e & = \frac{q_i + q_{in}}{b_i} \nonumber                             \\
+	p_e & = \frac{q_i + q_{in}}{b_i} \nonumber
+\end{align}
+
+\subsection{Swap sell derivations}\label{ssec:swap-sell-derivations}
+
+\subsubsection{Equation~\ref{eqn:swap-sell-quote-final-solved} derivation}%
+\label{sssec:equation-eqn-swap-sell-quote-final-solved-derivation}
+
+Consider Equation~\ref{eqn:swap-constant-product}.
+
+\begin{equation}
+	b_i \cdot q_i = b_f \cdot q_f \nonumber
+\end{equation}
+
+Substitute Equation~\ref{eqn:swap-sell-base-final}.
+
+\begin{equation}
+	b_i \cdot q_i = (b_i + b_{in}) \cdot q_f \nonumber
+\end{equation}
+
+Rearrange.
+
+\begin{equation}
+	q_f = \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber
+\end{equation}
+
+\subsubsection{Equation~\ref{eqn:swap-sell-quote-out-solved} derivation}%
+\label{sssec:equation-eqn-swap-sell-quote-out-solved-derivation}
+
+Consider Equation~\ref{eqn:swap-sell-quote-final}.
+
+\begin{equation}
+	q_f = q_i - q_{out} \nonumber
+\end{equation}
+
+Substitute Equation~\ref{eqn:swap-sell-quote-final-solved}.
+
+\begin{equation}
+	\frac{b_i \cdot q_i}{b_i + b_{in}}= q_i - q_{out} \nonumber
+\end{equation}
+
+Rearrange.
+
+\begin{align}
+	q_{out}                      & = q_i - \frac{b_i \cdot q_i}{b_i + b_{in}} \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} & = q_i \cdot (b_i + b_{in}) - b_i \cdot q_i \nonumber \\
+	(b_i + b_{in}) \cdot q_{out} & =
+	q_i \cdot b_i + q_i \cdot b_{in} - b_i \cdot q_i \nonumber                          \\
+	(b_i + b_{in}) \cdot q_{out} & =
+	b_i \cdot q_i + b_{in} \cdot q_i - b_i \cdot q_i \nonumber                          \\
+	(b_i + b_{in}) \cdot q_{out} & = b_{in} \cdot q_i \nonumber                         \\
+	q_{out}                      & = \frac{b_{in} \cdot q_i}{b_i + b_{in}} \nonumber
+\end{align}
+
+\subsubsection{Equation~\ref{eqn:swap-sell-execution-price-solved} derivation}%
+\label{sssec:equation-eqn-swap-sell-execution-price-solved-derivation}
+
+Consider Equation~\ref{eqn:swap-sell-execution-price}.
+
+\begin{equation}
+	p_e = \frac{q_{out}}{b_{in}} \nonumber
+\end{equation}
+
+Substitute Equation~\ref{eqn:swap-sell-quote-out-solved}.
+
+\begin{equation}
+	p_e = \dfrac{\left(\dfrac{q_i \cdot b_{in}}{b_i + b_{in}}\right)}{b_{in}} \nonumber
+\end{equation}
+
+Rearrange.
+
+\begin{align}
+	p_e & = \frac{q_i \cdot b_{in}}{b_{in} \cdot (b_i + b_{in})} \nonumber \\
+	p_e & = \frac{q_i}{b_i + b_{in}} \nonumber
 \end{align}
 
 \end{document} % chktex 17

--- a/research/amm/figures/swap-buy.tex
+++ b/research/amm/figures/swap-buy.tex
@@ -10,9 +10,9 @@
 			ytick=\empty,
 			xtick=\empty,
 			extra x ticks = {0.5, 2},
-			extra x tick labels = {$b_i$, $b_f$},
+			extra x tick labels = {$b_f$, $b_i$},
 			extra y ticks = {2, 0.5},
-			extra y tick labels = {$q_i$, $q_f$},
+			extra y tick labels = {$q_f$, $q_i$},
 			tick style = {thick, major tick length = 7pt},
 			legend style = {fill = black, draw = gray},
 			% Tangent lines on graph per https://tex.stackexchange.com/a/198046.
@@ -36,22 +36,22 @@
 			tangent,
 		] {1 / x};
 		% Initial price.
-		\node at (0.325, 2.15) [] {$p_i$};
-		\node at (0.5, 2) [circle, fill, scale = 0.5] {};
-		% Final price.
-		\node at (2.15, 0.325) [] {$p_f$};
+		\node at (2.15, 0.325) [] {$p_i$};
 		\node at (2, 0.5) [circle, fill, scale = 0.5] {};
+		% Final price.
+		\node at (0.325, 2.15) [] {$p_f$};
+		\node at (0.5, 2) [circle, fill, scale = 0.5] {};
 		% Execution price.
-		\draw [arrows = {-Latex[]}, thick] (0.5, 2) -- (2, 0.5);
+		\draw [arrows = {-Latex[]}, thick] (2, 0.5) -- (0.5, 2);
 		\node at (1.35, 1.35) [] {$p_e$};
 		% Base delta.
-		\node at (1.25, 0.25) [] {$b_{in}$};
-		\draw [arrows = {-Latex[]}] (0.5, 0.125) -- (2, 0.125);
+		\node at (1.25, 0.25) [] {$b_{out}$};
+		\draw [arrows = {-Latex[]}] (2, 0.125) -- (0.5, 0.125);
 		\draw [dashed] (0.5, 0) -- (0.5, 2);
 		\draw [dashed] (2, 0) -- (2, 0.5);
 		% Quote delta.
-		\node at (0.3, 1.25) [] {$q_{out}$};
-		\draw [arrows = {-Latex[]}] (0.125, 2) -- (0.125, 0.5);
+		\node at (0.3, 1.25) [] {$q_{in}$};
+		\draw [arrows = {-Latex[]}] (0.125, 0.5) -- (0.125, 2);
 		\draw [dashed] (0, 2) -- (0.5, 2);
 		\draw [dashed] (0, 0.5) -- (2, 0.5);
 	\end{axis}


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

1. Add a new `swap-buy` Ti*k*Z diagram.
1. Update `swap-sell` diagram for consistency in line commenting.
1. Add a new `Swap buy` subsection with derivations for simple cases.
1. Update derivations in `Swap sell` section for stylistic consistency.
1. Use silenced build command.

# Testing

Passes LaTeX CI.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
