### PR TITLE
test(ECO-3166): Remove `acquires` generic

### DIFF
--- a/research/prover-examples/sources/phantom_key_struct.move
+++ b/research/prover-examples/sources/phantom_key_struct.move
@@ -54,7 +54,7 @@ module prover_examples::phantom_key_struct {
 
     public fun increment_phantom_key_struct_with_rollover<T>(
         account: &signer
-    ) acquires PhantomKeyStruct<T> {
+    ) acquires PhantomKeyStruct {
         let value_ref_mut = &mut PhantomKeyStruct<T>[signer::address_of(account)].value;
         if (*value_ref_mut == MAX_VALUE) {
             *value_ref_mut = 0;


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Remove the generic parameter from an acquires statement that was breaking tests

# Testing

CI

# Checklist

- [x] Did you check all checkboxes from the linked Linear task? (Ignore if you
  are not a member of Econia Labs)
