### PR TITLE
ci(ECO-3306): Add CloudFormation quick-lint hook

### DIFF
--- a/cfg/pre-commit/quick-lint.yaml
+++ b/cfg/pre-commit/quick-lint.yaml
@@ -20,6 +20,12 @@ repos:
   repo: 'https://github.com/adrienverge/yamllint'
   rev: 'v1.37.1'
 - hooks:
+  # Lint all AWS CloudFormation files ending in `.cfn.yaml`.
+  - files: '.*\.cfn\.yaml'
+    id: 'cfn-lint'
+  repo: 'https://github.com/aws-cloudformation/cfn-lint'
+  rev: 'v1.35.3'
+- hooks:
   - args:
     - '--config'
     - 'cfg/markdownlint.yaml'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Add a `cfn-lint` hook to `quick-lint` pre-commit config

# Testing

This PR, actual AWS template file forthcoming

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?
