### PR TITLE
ci(ECO-3319): Add Cursor rules support

### DIFF
--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -1,5 +1,5 @@
 ---
-description:
+description: Code comments rules
 globs:
 alwaysApply: true
 ---

--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -1,0 +1,31 @@
+---
+description:
+globs:
+alwaysApply: true
+---
+# Code Comments Rules
+
+## Punctuation
+- All comments must end with a period.
+- This applies to both single-line and multi-line comments.
+
+## Examples
+
+### Single-line comments
+```python
+# This is a correct comment.
+# This is incorrect without a period
+```
+
+### Multi-line comments
+```python
+"""
+This is a correct multi-line comment.
+Each sentence should end with a period.
+"""
+
+"""
+This is incorrect
+No periods at the end of sentences
+"""
+```

--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -3,6 +3,7 @@ description: Code comments rules
 globs:
 alwaysApply: true
 ---
+
 # Code comments rules
 
 ## Punctuation

--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -3,21 +3,25 @@ description:
 globs:
 alwaysApply: true
 ---
+
 # Code Comments Rules
 
 ## Punctuation
+
 - All comments must end with a period.
 - This applies to both single-line and multi-line comments.
 
 ## Examples
 
 ### Single-line comments
+
 ```python
 # This is a correct comment.
 # This is incorrect without a period
 ```
 
 ### Multi-line comments
+
 ```python
 """
 This is a correct multi-line comment.

--- a/.cursor/rules/comments.mdc
+++ b/.cursor/rules/comments.mdc
@@ -3,8 +3,7 @@ description: Code comments rules
 globs:
 alwaysApply: true
 ---
-
-# Code Comments Rules
+# Code comments rules
 
 ## Punctuation
 

--- a/.cursor/rules/markdown.mdc
+++ b/.cursor/rules/markdown.mdc
@@ -1,11 +1,9 @@
 ---
-description:
+description: Markdown formatting and style
 globs: *.md
 alwaysApply: false
 ---
-# Markdown Formatting
-
-Description: Requirements for markdown files to pass linting
+# Markdown Formatting and style
 
 ## Requirements
 

--- a/.cursor/rules/markdown.mdc
+++ b/.cursor/rules/markdown.mdc
@@ -3,7 +3,7 @@ description: Markdown formatting and style
 globs: *.md
 alwaysApply: false
 ---
-# Markdown Formatting and style
+# Markdown formatting and style
 
 ## Requirements
 
@@ -11,7 +11,7 @@ All markdown files must pass:
 - `mdformat` formatting
 - `markdownlint-fix` linting
 
-## Code Blocks
+## Code blocks
 
 Always use `sh` instead of `bash` for shell code blocks.
 
@@ -23,6 +23,7 @@ Always use `sh` instead of `bash` for shell code blocks.
 ## Validation
 
 Run the following commands to validate:
+
 ```sh
 pre-commit run mdformat --config cfg/pre-commit/quick-lint.yaml --files <YOUR_FILE>
 pre-commit run markdownlint-fix --config cfg/pre-commit/quick-lint.yaml --files <YOUR_FILE>

--- a/.cursor/rules/markdown.mdc
+++ b/.cursor/rules/markdown.mdc
@@ -1,0 +1,31 @@
+---
+description:
+globs: *.md
+alwaysApply: false
+---
+# Markdown Formatting
+
+Description: Requirements for markdown files to pass linting
+
+## Requirements
+
+All markdown files must pass:
+- `mdformat` formatting
+- `markdownlint-fix` linting
+
+## Code Blocks
+
+Always use `sh` instead of `bash` for shell code blocks.
+
+## Style
+
+- Put a period at the end of items, like in lists.
+- Write titles in sentence case.
+
+## Validation
+
+Run the following commands to validate:
+```sh
+pre-commit run mdformat --config cfg/pre-commit/quick-lint.yaml --files <YOUR_FILE>
+pre-commit run markdownlint-fix --config cfg/pre-commit/quick-lint.yaml --files <YOUR_FILE>
+```

--- a/.cursor/rules/markdown.mdc
+++ b/.cursor/rules/markdown.mdc
@@ -3,11 +3,17 @@ description: Markdown formatting and style
 globs: *.md
 alwaysApply: false
 ---
+
+<!---
+cspell:word mdformat
+-->
+
 # Markdown formatting and style
 
 ## Requirements
 
 All markdown files must pass:
+
 - `mdformat` formatting
 - `markdownlint-fix` linting
 
@@ -25,6 +31,8 @@ Always use `sh` instead of `bash` for shell code blocks.
 Run the following commands to validate:
 
 ```sh
-pre-commit run mdformat --config cfg/pre-commit/quick-lint.yaml --files <YOUR_FILE>
-pre-commit run markdownlint-fix --config cfg/pre-commit/quick-lint.yaml --files <YOUR_FILE>
+pre-commit run mdformat --config cfg/pre-commit/quick-lint.yaml \
+    --files <YOUR_FILE>
+pre-commit run markdownlint-fix --config cfg/pre-commit/quick-lint.yaml \
+    --files <YOUR_FILE>
 ```

--- a/.cursor/rules/pr-linear.mdc
+++ b/.cursor/rules/pr-linear.mdc
@@ -3,6 +3,7 @@ description: Creating a PR from a Linear task
 globs:
 alwaysApply: false
 ---
+
 # PR rules for linear integration
 
 ## Branch Naming

--- a/.cursor/rules/pr-linear.mdc
+++ b/.cursor/rules/pr-linear.mdc
@@ -1,3 +1,8 @@
+---
+description: Creating a PR from a Linear task
+globs:
+alwaysApply: false
+---
 # PR Rules for Linear Integration
 
 ## Branch Naming

--- a/.cursor/rules/pr-linear.mdc
+++ b/.cursor/rules/pr-linear.mdc
@@ -3,18 +3,23 @@ description: Creating a PR from a Linear task
 globs:
 alwaysApply: false
 ---
+
 # PR Rules for Linear Integration
 
 ## Branch Naming
+
 - Branch names must match the Linear issue ID format: `ECO-[0-9]+`
 - Example: `ECO-123`
 
 ## PR Title and Commit Messages
-- Must follow the semantic PR workflow requirements in `.github/workflows/semantic-pr.yaml`
+
+- Must follow the semantic PR workflow requirements in
+  `.github/workflows/semantic-pr.yaml`
 - Scope must be the Linear issue ID (e.g., `ECO-123`)
 - Commit message must match PR title exactly if there is only 1 commit
 
 ## Linear Integration
+
 - PRs should be created from Linear tasks
 - Branch names should be derived from Linear issue IDs
 - PR titles should reference Linear issue IDs in the scope

--- a/.cursor/rules/pr-linear.mdc
+++ b/.cursor/rules/pr-linear.mdc
@@ -18,6 +18,12 @@ alwaysApply: false
 - Scope must be the Linear issue ID (e.g., `ECO-123`)
 - Commit message must match PR title exactly if there is only 1 commit
 
+## PR Description
+
+- The PR description should use the template at
+  `.github/PULL_REQUEST_TEMPLATE.md`, and should leave the checkbox unchecked.
+- The PR description should pass the `markdown` rule.
+
 ## Linear Integration
 
 - PRs should be created from Linear tasks

--- a/.cursor/rules/pr-linear.mdc
+++ b/.cursor/rules/pr-linear.mdc
@@ -3,20 +3,19 @@ description: Creating a PR from a Linear task
 globs:
 alwaysApply: false
 ---
-
-# PR Rules for Linear Integration
+# PR rules for linear integration
 
 ## Branch Naming
 
-- Branch names must match the Linear issue ID format: `ECO-[0-9]+`
-- Example: `ECO-123`
+- Branch names must match the Linear issue ID format: `ECO-[0-9]+`.
+- Example: `ECO-123`.
 
 ## PR Title and Commit Messages
 
 - Must follow the semantic PR workflow requirements in
-  `.github/workflows/semantic-pr.yaml`
-- Scope must be the Linear issue ID (e.g., `ECO-123`)
-- Commit message must match PR title exactly if there is only 1 commit
+  `.github/workflows/semantic-pr.yaml`.
+- Scope must be the Linear issue ID (e.g., `ECO-123`).
+- Commit message must match PR title exactly if there is only 1 commit.
 
 ## PR Description
 
@@ -26,6 +25,6 @@ alwaysApply: false
 
 ## Linear Integration
 
-- PRs should be created from Linear tasks
-- Branch names should be derived from Linear issue IDs
-- PR titles should reference Linear issue IDs in the scope
+- PRs should be created from Linear tasks.
+- Branch names should be derived from Linear issue IDs.
+- PR titles should reference Linear issue IDs in the scope.

--- a/.cursor/rules/pr-linear.yaml
+++ b/.cursor/rules/pr-linear.yaml
@@ -1,0 +1,15 @@
+# PR Rules for Linear Integration
+
+## Branch Naming
+- Branch names must match the Linear issue ID format: `ECO-[0-9]+`
+- Example: `ECO-123`
+
+## PR Title and Commit Messages
+- Must follow the semantic PR workflow requirements in `.github/workflows/semantic-pr.yaml`
+- Scope must be the Linear issue ID (e.g., `ECO-123`)
+- Commit message must match PR title exactly if there is only 1 commit
+
+## Linear Integration
+- PRs should be created from Linear tasks
+- Branch names should be derived from Linear issue IDs
+- PR titles should reference Linear issue IDs in the scope

--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -3,6 +3,7 @@ description: Guidelines for creating Cursor rules.
 globs:
 alwaysApply: false
 ---
+
 # Cursor rule creation guidelines
 
 ## Requirements
@@ -11,4 +12,3 @@ All rule files must:
 
 - Use `.mdc` extension.
 - Pass the `markdown` rule at `.cursor/rules/markdown.mdc`.
-

--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -1,0 +1,28 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Rule Creation Guidelines
+
+Description: Guidelines for creating rules in the `.cursor/rules` directory
+
+## Requirements
+
+All rule files must:
+
+- Use `.mdc` extension
+- Pass both `mdformat` and `markdownlint-fix` hooks
+
+## Validation
+
+Run the following commands to validate your rule:
+
+```sh
+pre-commit run mdformat --config cfg/pre-commit/quick-lint.yaml --files .cursor/rules/your-rule.mdc
+pre-commit run markdownlint-fix --config cfg/pre-commit/quick-lint.yaml --files .cursor/rules/your-rule.mdc
+```
+
+
+
+

--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -3,12 +3,12 @@ description: Guidelines for creating Cursor rules.
 globs:
 alwaysApply: false
 ---
-# Cursor Rule Creation Guidelines
+# Cursor rule creation guidelines
 
 ## Requirements
 
 All rule files must:
 
-- Use `.mdc` extension
-- Pass the `markdown` rule at `.cursor/rules/markdown.mdc`
+- Use `.mdc` extension.
+- Pass the `markdown` rule at `.cursor/rules/markdown.mdc`.
 

--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -1,28 +1,14 @@
 ---
-description:
+description: Guidelines for creating Cursor rules.
 globs:
 alwaysApply: false
 ---
-# Rule Creation Guidelines
-
-Description: Guidelines for creating rules in the `.cursor/rules` directory
+# Cursor Rule Creation Guidelines
 
 ## Requirements
 
 All rule files must:
 
 - Use `.mdc` extension
-- Pass both `mdformat` and `markdownlint-fix` hooks
-
-## Validation
-
-Run the following commands to validate your rule:
-
-```sh
-pre-commit run mdformat --config cfg/pre-commit/quick-lint.yaml --files .cursor/rules/your-rule.mdc
-pre-commit run markdownlint-fix --config cfg/pre-commit/quick-lint.yaml --files .cursor/rules/your-rule.mdc
-```
-
-
-
+- Pass the `markdown` rule at `.cursor/rules/markdown.mdc`
 

--- a/.cursor/rules/yaml.mdc
+++ b/.cursor/rules/yaml.mdc
@@ -3,8 +3,7 @@ description: YAML style
 globs: *.yaml
 alwaysApply: false
 ---
-
-# YAML Rules
+# YAML rules
 
 Use yamllint configuration from `cfg/yamllint.yaml` for all YAML file generation
 and validation.

--- a/.cursor/rules/yaml.mdc
+++ b/.cursor/rules/yaml.mdc
@@ -3,12 +3,16 @@ description:
 globs: *.yaml
 alwaysApply: false
 ---
+
 # YAML Rules
 
-Use yamllint configuration from `cfg/yamllint.yaml` for all YAML file generation and validation.
+Use yamllint configuration from `cfg/yamllint.yaml` for all YAML file generation
+and validation.
 
 ## File Extensions
+
 Always use the `.yaml` extension for new YAML files, not `.yml`.
 
 ## Lint
+
 Config: cfg/yamllint.yaml

--- a/.cursor/rules/yaml.mdc
+++ b/.cursor/rules/yaml.mdc
@@ -3,6 +3,7 @@ description: YAML style
 globs: *.yaml
 alwaysApply: false
 ---
+
 # YAML rules
 
 Use yamllint configuration from `cfg/yamllint.yaml` for all YAML file generation

--- a/.cursor/rules/yaml.mdc
+++ b/.cursor/rules/yaml.mdc
@@ -1,0 +1,14 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# YAML Rules
+
+Use yamllint configuration from `cfg/yamllint.yaml` for all YAML file generation and validation.
+
+## File Extensions
+Always use the `.yaml` extension for new YAML files, not `.yml`.
+
+## Lint
+Config: cfg/yamllint.yaml

--- a/.cursor/rules/yaml.mdc
+++ b/.cursor/rules/yaml.mdc
@@ -1,6 +1,6 @@
 ---
 description:
-globs:
+globs: *.yaml
 alwaysApply: false
 ---
 # YAML Rules

--- a/.cursor/rules/yaml.mdc
+++ b/.cursor/rules/yaml.mdc
@@ -1,5 +1,5 @@
 ---
-description:
+description: YAML style
 globs: *.yaml
 alwaysApply: false
 ---

--- a/cfg/pre-commit/quick-lint.yaml
+++ b/cfg/pre-commit/quick-lint.yaml
@@ -21,7 +21,7 @@ repos:
   rev: 'v1.37.1'
 - hooks:
   # Lint all AWS CloudFormation files ending in `.cfn.yaml`.
-  - files: '.*\.cfn\.yaml'
+  - files: '.cfn.yaml'
     id: 'cfn-lint'
   repo: 'https://github.com/aws-cloudformation/cfn-lint'
   rev: 'v1.35.3'
@@ -29,8 +29,10 @@ repos:
   - args:
     - '--config'
     - 'cfg/markdownlint.yaml'
-    files: '.*\.(md|mdc)$'
+    files: '\.(md|mdc)$'
     id: 'markdownlint-fix'
+    types:
+    - 'file'
   repo: 'https://github.com/igorshubovych/markdownlint-cli'
   rev: 'v0.45.0'
 - hooks:
@@ -38,9 +40,11 @@ repos:
     - 'mdformat-gfm'
     - 'mdformat-frontmatter'
     - 'mdformat-myst'
-    files: '.*\.(md|mdc)$'
+    files: '\.(md|mdc)$'
     id: 'mdformat'
-  repo: 'https://github.com/executablebooks/mdformat'
+    types:
+    - 'file'
+  repo: 'https://github.com/hukkin/mdformat'
   rev: '0.7.22'
 - hooks:
   - args:

--- a/cfg/pre-commit/quick-lint.yaml
+++ b/cfg/pre-commit/quick-lint.yaml
@@ -20,7 +20,6 @@ repos:
   repo: 'https://github.com/adrienverge/yamllint'
   rev: 'v1.37.1'
 - hooks:
-  # Lint all AWS CloudFormation files ending in `.cfn.yaml`.
   - files: '.cfn.yaml'
     id: 'cfn-lint'
   repo: 'https://github.com/aws-cloudformation/cfn-lint'
@@ -29,7 +28,7 @@ repos:
   - args:
     - '--config'
     - 'cfg/markdownlint.yaml'
-    files: '\.(md|mdc)$'
+    files: '.(md|mdc)'
     id: 'markdownlint-fix'
     types:
     - 'file'
@@ -40,7 +39,7 @@ repos:
     - 'mdformat-gfm'
     - 'mdformat-frontmatter'
     - 'mdformat-myst'
-    files: '\.(md|mdc)$'
+    files: '.(md|mdc)'
     id: 'mdformat'
     types:
     - 'file'

--- a/cfg/pre-commit/quick-lint.yaml
+++ b/cfg/pre-commit/quick-lint.yaml
@@ -29,6 +29,7 @@ repos:
   - args:
     - '--config'
     - 'cfg/markdownlint.yaml'
+    files: '.*\.(md|mdc)$'
     id: 'markdownlint-fix'
   repo: 'https://github.com/igorshubovych/markdownlint-cli'
   rev: 'v0.45.0'
@@ -37,6 +38,7 @@ repos:
     - 'mdformat-gfm'
     - 'mdformat-frontmatter'
     - 'mdformat-myst'
+    files: '.*\.(md|mdc)$'
     id: 'mdformat'
   repo: 'https://github.com/executablebooks/mdformat'
   rev: '0.7.22'


### PR DESCRIPTION
<!-- markdownlint-disable-file MD025 -->

# Description

Add Cursor rules and update the quick lint config to support them.

# Testing

Rules run against rules locally.

# Checklist

- [x] Did you check all checkboxes from the linked Linear task?
